### PR TITLE
Single GPU version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ elseif("$ENV{SYST}" STREQUAL "FX-Fujitsu")
 # nVidia Fortran compiler
 elseif("$ENV{SYST}" STREQUAL "NV-OpenACC")
     set(CMAKE_Fortran_COMPILER "mpif90")
-    set(CMAKE_Fortran_FLAGS "-W -Wall -acc -Minfo=accel -gpu=ccall -Mpreprocess -Mr8 -Mfree -Werror" CACHE STRING "")
+    set(CMAKE_Fortran_FLAGS "-W -Wall -acc=gpu,host -cuda -Minfo=accel -gpu=ccnative,fastmath -Mpreprocess -Mr8 -Mfree -Werror" CACHE STRING "")
     set(CMAKE_Fortran_FLAGS_RELEASE "-Munroll -Ofast -g -traceback" CACHE STRING "")
     set(CMAKE_Fortran_FLAGS_DEBUG "-Minit-real=snan -traceback -O0 -g -ffpe-trap=invalid,zero,overflow" CACHE STRING "")
 elseif("$ENV{SYST}" STREQUAL "NV-multicore")

--- a/src/advec_2nd.f90
+++ b/src/advec_2nd.f90
@@ -52,7 +52,7 @@ subroutine advecc_2nd(a_in,a_out)
 !      end do
 !    end do
 !  end do
-  !$acc parallel loop collapse(3) default(present)
+  !$acc parallel loop collapse(3) default(present) async(1)
   do k=1,kmax
     do j=2,j1
       do i=2,i1
@@ -71,7 +71,7 @@ subroutine advecc_2nd(a_in,a_out)
   end do
 
   if (leq) then ! equidistant grid
-    !$acc parallel loop collapse(2) default(present)
+    !$acc parallel loop collapse(2) default(present) async(1)
     do j=2,j1
       do i=2,i1
         a_out(i,j,1)  = a_out(i,j,1)- (1./rhobf(1))*( &
@@ -80,7 +80,7 @@ subroutine advecc_2nd(a_in,a_out)
       end do
     end do
     
-    !$acc parallel loop collapse(3) default(present)
+    !$acc parallel loop collapse(3) default(present) async(1)
     do j=2,j1
       do k=2,kmax         
         do i=2,i1
@@ -93,7 +93,7 @@ subroutine advecc_2nd(a_in,a_out)
     end do
 
   else   ! non-equidistant grid
-    !$acc parallel loop collapse(2) default(present)
+    !$acc parallel loop collapse(2) default(present) async(1)
     do j=2,j1
       do i=2,i1
         a_out(i,j,1)  = a_out(i,j,1)- (1./rhobf(1))*( &
@@ -101,7 +101,7 @@ subroutine advecc_2nd(a_in,a_out)
                 ) / dzf(1)
       end do
     end do
-    !$acc parallel loop collapse(3) default(present)
+    !$acc parallel loop collapse(3) default(present) async(1)
     do j=2,j1
       do k=2,kmax
         do i=2,i1

--- a/src/modboundary.f90
+++ b/src/modboundary.f90
@@ -89,7 +89,8 @@ contains
 !> Cleans up after the run
   subroutine exitboundary
   implicit none
-    deallocate(tsc)
+  !$acc exit data delete(tsc)
+  deallocate(tsc)
   end subroutine exitboundary
 
 !> Sets lateral periodic boundary conditions for the scalars

--- a/src/modboundary.f90
+++ b/src/modboundary.f90
@@ -154,7 +154,7 @@ contains
   select case(igrw_damp)
   case(0) !do nothing
   case(1)
-    !$acc kernels default(present)
+    !$acc kernels default(present) async(1)
     do k=ksp,kmax
       up(:,:,k)  = up(:,:,k)-(u0(:,:,k)-(u0av(k)-cu))*tsc(k)
       vp(:,:,k)  = vp(:,:,k)-(v0(:,:,k)-(v0av(k)-cv))*tsc(k)
@@ -164,7 +164,7 @@ contains
     end do
     !$acc end kernels
     if(lcoriol) then
-    !$acc kernels default(present)
+    !$acc kernels default(present) async(1)
     do k=ksp,kmax
       up(:,:,k)  = up(:,:,k)-(u0(:,:,k)-(ug(k)-cu))*((1./(geodamptime*rnu0))*tsc(k))
       vp(:,:,k)  = vp(:,:,k)-(v0(:,:,k)-(vg(k)-cv))*((1./(geodamptime*rnu0))*tsc(k))
@@ -172,7 +172,7 @@ contains
     !$acc end kernels
     end if
   case(2)
-    !$acc kernels default(present)
+    !$acc kernels default(present) async(1)
     do k=ksp,kmax
       up(:,:,k)  = up(:,:,k)-(u0(:,:,k)-(ug(k)-cu))*tsc(k)
       vp(:,:,k)  = vp(:,:,k)-(v0(:,:,k)-(vg(k)-cv))*tsc(k)
@@ -182,7 +182,7 @@ contains
     end do
     !$acc end kernels
   case(3)
-    !$acc kernels default(present)
+    !$acc kernels default(present) async(1)
     do k=ksp,kmax
       up(:,:,k)  = up(:,:,k)-(u0(:,:,k)-(u0av(k)-cu))*tsc(k)
       vp(:,:,k)  = vp(:,:,k)-(v0(:,:,k)-(v0av(k)-cv))*tsc(k)
@@ -192,7 +192,7 @@ contains
     end do
     !$acc end kernels
   case(-1)
-    !$acc kernels default(present)
+    !$acc kernels default(present) async(1)
     up(:,:,:) = up(:,:,:) - unudge * ( sum((u0av(1:kmax) - ug(1:kmax)) * dzf(1:kmax)) / sum(dzf(1:kmax)) ) / rdt
     vp(:,:,:) = vp(:,:,:) - unudge * ( sum((v0av(1:kmax) - vg(1:kmax)) * dzf(1:kmax)) / sum(dzf(1:kmax)) ) / rdt
     !$acc end kernels
@@ -204,16 +204,20 @@ contains
   ! at level kmax.
   ! Originally done in subroutine tqaver, now using averages from modthermodynamics
 
-  !$acc kernels default(present)
+  !$acc kernels default(present) async(1)
   thl0(2:i1,2:j1,kmax) = thl0av(kmax)
   qt0 (2:i1,2:j1,kmax) = qt0av(kmax)
   !$acc end kernels
 
-  !$acc kernels default(present) if(nsv > 0)
-  do n=1,nsv
-    sv0(2:i1,2:j1,kmax,n) = sv0av(kmax,n)
-  end do
-  !$acc end kernels
+  if (nsv > 0) then
+    !$acc kernels default(present) async(1)
+    do n=1,nsv
+      sv0(2:i1,2:j1,kmax,n) = sv0av(kmax,n)
+    end do
+    !$acc end kernels
+  end if
+
+  !$acc wait
 
   return
   end subroutine grwdamp

--- a/src/modbudget.f90
+++ b/src/modbudget.f90
@@ -185,8 +185,10 @@ contains
 
 !> General routine, does the timekeeping
   subroutine budgetstat
-
     use modglobal, only : rk3step,timee, dt_lim
+#if defined(_OPENACC)
+    use modgpu, only: update_host
+#endif
     implicit none
 
     if (.not. lbudget) return
@@ -197,6 +199,9 @@ contains
     end if
     if (timee>=tnext) then
       tnext = tnext+idtav
+#if defined(_OPENACC)
+      call update_host
+#endif
       call do_genbudget
       call do_gensbbudget
     end if

--- a/src/modcape.f90
+++ b/src/modcape.f90
@@ -121,6 +121,9 @@ contains
     use modgenstat, only : qlmnlast,wthvtmnlast
     use modmicrodata, only : iqr, precep, imicro
     use modmpi
+#if defined(_OPENACC)
+    use modgpu, only: update_host
+#endif
     implicit none
 
     real, allocatable :: dcape(:,:),dscape(:,:),dcin(:,:),dscin(:,:),dcintot(:,:),capemax(:,:),&
@@ -143,6 +146,10 @@ contains
     end if
     tnext = tnext+idtav
     dt_lim = minval((/dt_lim,tnext-timee/))
+
+#if defined(_OPENACC)
+    call update_host
+#endif
 
     allocate(dcape(2:i1,2:j1),dscape(2:i1,2:j1),dcin(2:i1,2:j1),dscin(2:i1,2:j1),dcintot(2:i1,2:j1))
     allocate(capemax(2:i1,2:j1),cinmax(2:i1,2:j1),hw2cb(2:i1,2:j1))

--- a/src/modcloudfield.f90
+++ b/src/modcloudfield.f90
@@ -79,6 +79,9 @@ contains
     use modglobal, only : imax,i1,jmax,j1,kmax, rk3step,dt_lim,timee,rtimee, cexpnr,ifoutput
     use modfields, only : w0,ql0
     use modmpi,    only : cmyid
+#if defined(_OPENACC)
+    use modgpu, only: update_host
+#endif
     implicit none
 
     integer  :: ncl
@@ -94,6 +97,10 @@ contains
     end if
     tnext = tnext+idtav
     dt_lim = minval((/dt_lim,tnext-timee/))
+
+#if defined(_OPENACC)
+    call update_host
+#endif
 
     ncl  = imax*jmax*kmax
     allocate (ipos(ncl),jpos(ncl),kpos(ncl),wcl(ncl),qlcl(ncl))

--- a/src/modcrosssection.f90
+++ b/src/modcrosssection.f90
@@ -243,6 +243,9 @@ contains
   subroutine crosssection
     use modglobal, only : rk3step,timee,dt_lim
     use modstat_nc, only : writestat_nc
+#if defined(_OPENACC)
+    use modgpu, only: update_host
+#endif
     implicit none
 
 
@@ -252,6 +255,9 @@ contains
       dt_lim = min(dt_lim,tnext-timee)
       return
     end if
+#if defined(_OPENACC)
+    call update_host
+#endif
     tnext = tnext+idtav
     dt_lim = minval((/dt_lim,tnext-timee/))
 

--- a/src/modcufft.f90
+++ b/src/modcufft.f90
@@ -207,7 +207,9 @@ module modcufft
       real(pois_r), pointer :: p(:,:,:), Fp(:,:,:)
       real(pois_r), allocatable :: d(:,:,:), xyrt(:,:,:)
 
-      deallocate(d, xyrt)
+      !$acc exit data delete(xyrt, d, p_halo, p_nohalo)
+
+      deallocate(d, xyrt, p_halo, p_nohalo)
 
       nullify(p, Fp)
 

--- a/src/modcufft.f90
+++ b/src/modcufft.f90
@@ -20,11 +20,13 @@ module modcufft
 
     integer :: planx, planxi, plany, planyi !< Plan handles
 
+    integer(int_ptr_kind()) :: worksize, max_worksize !< Size of the required workspace
+
   contains
     !< Setup plans, workspace, etc
     subroutine cufftinit(p, Fp, d, xyrt, ps, pe, qs, qe)
       use cufft
-      use modgpu, only: allocate_workspace
+      use modgpu, only: workspace, allocate_workspace
 
       implicit none
 
@@ -44,8 +46,6 @@ module modcufft
       p(2-ih:i1+ih,2-jh:j1+jh,1:kmax) => p_halo(1:(imax+2*ih)*(jmax+2*jh)*kmax)
       Fp(2-ih:i1+ih,2-jh:j1+jh,1:kmax) => p_halo(1:(imax+2*ih)*(jmax+2*jh)*kmax)
 
-      ! TODO: use cufftMakePlanMany and manually allocate workspace
-
       ! Number of complex coefficients
       itot12 = itot/2 + 1
       jtot12 = jtot/2 + 1
@@ -55,7 +55,6 @@ module modcufft
       ! consists of two real numbers
       allocate(p_nohalo(kmax*(itot12*2)*(jtot12*2)))
       !$acc enter data create(p_nohalo)
-      call allocate_workspace(itot12*2, jtot12*2, kmax)
 
       px(1:itot12*2,1:jtot,1:kmax) => p_nohalo(1:kmax*jtot*(itot12*2))
       py(1:jtot12*2,1:itot,1:kmax) => p_nohalo(1:kmax*itot*(jtot12*2))
@@ -78,6 +77,7 @@ module modcufft
       istride = 1
       ostride = 1
 
+      istat = cufftSetAutoAllocation(planx, 0)
       istat = cufftPlanMany( &
         planx, &
         1, &
@@ -91,9 +91,9 @@ module modcufft
         CUFFT_FWD_TYPE, &
         jtot*kmax &
       )
-
       call check_exitcode(istat)
 
+      istat = cufftSetAutoAllocation(planxi, 0)
       istat = cufftPlanMany( &
         planxi, &
         1, &
@@ -120,6 +120,7 @@ module modcufft
       istride = 1
       ostride = 1
 
+      istat = cufftSetAutoAllocation(plany, 0)
       istat = cufftPlanMany( &
         plany, &
         1, &
@@ -136,6 +137,7 @@ module modcufft
 
       call check_exitcode(istat)
 
+      istat = cufftSetAutoAllocation(planyi, 0)
       istat = cufftPlanMany( &
         planyi, &
         1, &
@@ -149,6 +151,34 @@ module modcufft
         CUFFT_BWD_TYPE, &
         itot*kmax &
       )
+
+      call check_exitcode(istat)
+
+      ! Determine the workspace needed for FFTs and transposes
+      max_worksize = -1
+      
+      istat = cufftGetSize(planx, worksize)
+      max_worksize = max(max_worksize, worksize)
+      istat = cufftGetSize(planxi, worksize)
+      max_worksize = max(max_worksize, worksize)
+      istat = cufftGetSize(plany, worksize)
+      max_worksize = max(max_worksize, worksize)
+      istat = cufftGetSize(planyi, worksize)
+      max_worksize = max(max_worksize, worksize)
+      
+      ! max_worksize is in bytes, so convert it to number of elements by dividing by the size of a real number
+      worksize = max_worksize / (storage_size(1._pois_r) / 8)
+
+      worksize = max(worksize, ((itot12*2)*(jtot12*2)*kmax))
+
+      call allocate_workspace(int(worksize))
+
+      !$acc host_data use_device(workspace)
+      istat = cufftSetWorkArea(planx, workspace)
+      istat = cufftSetWorkArea(planxi, workspace)
+      istat = cufftSetWorkArea(plany, workspace)
+      istat = cufftSetWorkArea(planyi, workspace)
+      !$acc end host_data
 
       call check_exitcode(istat)
 

--- a/src/modfielddump.f90
+++ b/src/modfielddump.f90
@@ -195,6 +195,9 @@ contains
     use modmpi,    only : myid,cmyidx, cmyidy
     use modstat_nc, only : lnetcdf, writestat_nc
     use modmicrodata, only : iqr, imicro, imicro_none
+#if defined(_OPENACC)
+    use modgpu, only: update_host
+#endif
     implicit none
 
     integer(KIND=selected_int_kind(4)), allocatable :: field(:,:,:)
@@ -217,6 +220,10 @@ contains
 
     ! Only write fields if time is in the range (tmin, tmax)
     if (timee < itmin .or. timee > itmax) return
+
+#if defined(_OPENACC)
+    call update_host
+#endif
 
     if (lbinary) allocate(field(2-ih:i1+ih,2-jh:j1+jh,k1))
     if (lnetcdf) allocate(vars(ceiling(1.0*imax/ncoarse),ceiling(1.0*jmax/ncoarse),khigh-klow+1,nvar))

--- a/src/modforces.f90
+++ b/src/modforces.f90
@@ -71,7 +71,7 @@ contains
   if (lforce_user) call force_user
 
   if (lpressgrad) then
-     !$acc kernels default(present)
+     !$acc kernels default(present) async(1)
      do k=1,kmax
         up(:,:,k) = up(:,:,k) - dpdxl(k)      !RN LS pressure gradient force in x,y directions;
         vp(:,:,k) = vp(:,:,k) - dpdyl(k)
@@ -80,14 +80,14 @@ contains
   end if
 
   if((imicro==imicro_sice).or.(imicro==imicro_sice2).or.(imicro==imicro_bulk).or.(imicro==imicro_bin)) then
-    !$acc kernels default(present)
+    !$acc kernels default(present) async(2)
     do k=2,kmax
        wp(:,:,k) = wp(:,:,k) + grav*(thv0h(:,:,k)-thvh(k))/thvh(k) - &
                   grav*(sv0(:,:,k,iqr)*dzf(k-1)+sv0(:,:,k-1,iqr)*dzf(k))/(2.0*dzh(k))
     end do
     !$acc end kernels
   else
-    !$acc kernels default(present)
+    !$acc kernels default(present) async(2)
     do k=2,kmax
       wp(:,:,k) = wp(:,:,k) + grav*(thv0h(:,:,k)-thvh(k))/thvh(k)
     end do
@@ -97,9 +97,11 @@ contains
 !     --------------------------------------------
 !     special treatment for lowest full level: k=1
 !     --------------------------------------------
-  !$acc kernels default(present)
+  !$acc kernels default(present) async(3)
   wp(:,:,1) = 0.0
   !$acc end kernels
+
+  !$acc wait
 
   end subroutine forces
   subroutine coriolis

--- a/src/modforces.f90
+++ b/src/modforces.f90
@@ -203,7 +203,7 @@ contains
                         dqtdtls, dthldtls, dudtls, dvdtls
   implicit none
 
-  integer k
+  integer i, j, k, n
 
 !     1. DETERMINE LARGE SCALE TENDENCIES
 !        --------------------------------
@@ -211,47 +211,93 @@ contains
 !     1.1 lowest model level above surface : only downward component
 !     1.2 other model levels twostream
 
-  !$acc kernels default(present)
+  !$acc parallel loop gang default(present) async(1)
   do k=1,kmax
-    if (whls(k+1).lt.0) then   !downwind scheme for subsidence
-       thlp(2:i1,2:j1,k) = thlp(2:i1,2:j1,k) - whls(k+1) * (thl0(2:i1,2:j1,k+1) - thl0(2:i1,2:j1,k))/dzh(k+1)
-       qtp (2:i1,2:j1,k) = qtp (2:i1,2:j1,k) - whls(k+1) * (qt0 (2:i1,2:j1,k+1) - qt0 (2:i1,2:j1,k))/dzh(k+1)
-       if (lmomsubs) then
-          up(2:i1,2:j1,k) = up(2:i1,2:j1,k) - whls(k+1) * (u0(2:i1,2:j1,k+1) - u0(2:i1,2:j1,k))/dzh(k+1)
-          vp(2:i1,2:j1,k) = vp(2:i1,2:j1,k) - whls(k+1) * (v0(2:i1,2:j1,k+1) - v0(2:i1,2:j1,k))/dzh(k+1)
-       endif
+    if (whls(k+1) < 0) then   !downwind scheme for subsidence
+      !$acc loop collapse(2)
+      do j=2,j1
+        do i=2,i1
+          thlp(i,j,k) = thlp(i,j,k) - whls(k+1) * (thl0(i,j,k+1) - thl0(i,j,k))/dzh(k+1)
+          qtp (i,j,k) = qtp (i,j,k) - whls(k+1) * (qt0 (i,j,k+1) - qt0 (i,j,k))/dzh(k+1)
+        end do
+      end do
     else !downwind scheme for mean upward motions
-       if (k > 1) then !neglect effect of mean ascending on tendencies at the lowest full level
-          thlp(2:i1,2:j1,k) = thlp(2:i1,2:j1,k) - whls(k) * (thl0(2:i1,2:j1,k) - thl0(2:i1,2:j1,k-1))/dzh(k)
-          qtp (2:i1,2:j1,k) = qtp (2:i1,2:j1,k) - whls(k) * (qt0 (2:i1,2:j1,k) - qt0 (2:i1,2:j1,k-1))/dzh(k)
-          if (lmomsubs) then
-             up(2:i1,2:j1,k) = up(2:i1,2:j1,k) - whls(k) * (u0(2:i1,2:j1,k) - u0(2:i1,2:j1,k-1))/dzh(k)
-             vp(2:i1,2:j1,k) = vp(2:i1,2:j1,k) - whls(k) * (v0(2:i1,2:j1,k) - v0(2:i1,2:j1,k-1))/dzh(k)
-          endif
-       endif
+      if (k > 1) then !neglect effect of mean ascending on tendencies at the lowest full level
+        !$acc loop collapse(2)
+        do j=2,j1
+          do i=2,i1
+            thlp(i,j,k) = thlp(i,j,k) - whls(k) * (thl0(i,j,k) - thl0(i,j,k-1))/dzh(k)
+            qtp (i,j,k) = qtp (i,j,k) - whls(k) * (qt0 (i,j,k) - qt0 (i,j,k-1))/dzh(k)
+          end do
+        end do
+      endif
     endif
+  end do
 
-    thlp(2:i1,2:j1,k) = thlp(2:i1,2:j1,k)-u0av(k)*dthldxls(k)-v0av(k)*dthldyls(k) + dthldtls(k)
-    qtp (2:i1,2:j1,k) = qtp (2:i1,2:j1,k)-u0av(k)*dqtdxls (k)-v0av(k)*dqtdyls (k) + dqtdtls(k)
-    up  (2:i1,2:j1,k) = up  (2:i1,2:j1,k)-u0av(k)*dudxls  (k)-v0av(k)*dudyls  (k) + dudtls(k)
-    vp  (2:i1,2:j1,k) = vp  (2:i1,2:j1,k)-u0av(k)*dvdxls  (k)-v0av(k)*dvdyls  (k) + dvdtls(k)
-  enddo
-  !$acc end kernels
+  if (lmomsubs) then
+    !$acc parallel loop gang default(present) async(2)
+    do k=1,kmax
+      if (whls(k+1) < 0) then
+        !$acc loop collapse(2)
+        do j=1,j1
+          do i=1,i1
+            up(i,j,k) = up(i,j,k) - whls(k+1) * (u0(i,j,k+1) - u0(i,j,k))/dzh(k+1)
+            vp(i,j,k) = vp(i,j,k) - whls(k+1) * (v0(i,j,k+1) - v0(i,j,k))/dzh(k+1)
+          end do
+        end do
+      else
+        if (k > 1) then
+          !$acc loop collapse(2)
+          do j=1,j1
+            do i=1,i1 
+              up(i,j,k) = up(i,j,k) - whls(k) * (u0(i,j,k) - u0(i,j,k-1))/dzh(k)
+              vp(i,j,k) = vp(i,j,k) - whls(k) * (v0(i,j,k) - v0(i,j,k-1))/dzh(k)
+            end do
+          end do
+        end if
+      end if
+    end do
+  end if 
+  
+  !$acc parallel loop collapse(3) async wait(1,2)
+  do k=1,kmax
+    do j=2,j1
+      do i=2,i1
+        thlp(i,j,k) = thlp(i,j,k)-u0av(k)*dthldxls(k)-v0av(k)*dthldyls(k) + dthldtls(k)
+        qtp (i,j,k) = qtp (i,j,k)-u0av(k)*dqtdxls (k)-v0av(k)*dqtdyls (k) + dqtdtls(k)
+        up  (i,j,k) = up  (i,j,k)-u0av(k)*dudxls  (k)-v0av(k)*dudyls  (k) + dudtls(k)
+        vp  (i,j,k) = vp  (i,j,k)-u0av(k)*dvdxls  (k)-v0av(k)*dvdyls  (k) + dvdtls(k)
+      end do
+    end do
+  end do
   
   ! Only do above for scalars if there are any scalar fields
   if (nsv > 0) then
-    !$acc kernels default(present)
-    do k=1,kmax
-      if (whls(k+1).lt.0) then
-         svp(2:i1,2:j1,k,:) = svp(2:i1,2:j1,k,:) - whls(k+1) * (sv0(2:i1,2:j1,k+1,:) - sv0(2:i1,2:j1,k,:))/dzh(k+1)
-      else
-        if (k > 1) then
-          svp(2:i1,2:j1,k,:) = svp(2:i1,2:j1,k,:)-whls(k) * (sv0(2:i1,2:j1,k,:) - sv0(2:i1,2:j1,k-1,:))/dzh(k)
-        endif
-      endif
-    enddo
-    !$acc end kernels
-  endif
+    do n=1,nsv
+      !$acc parallel loop gang default(present) async
+      do k=1,kmax
+        if (whls(k+1).lt.0) then
+          !$acc loop collapse(2)
+          do j=1,j1
+            do i=1,i1
+              svp(i,j,k,n) = svp(i,j,k,n) - whls(k+1) * (sv0(i,j,k+1,n) - sv0(i,j,k,n))/dzh(k+1)
+            end do
+          end do
+        else
+          if (k > 1) then
+            !$acc loop collapse(2)
+            do j=1,j1
+              do i=1,i1
+                svp(i,j,k,n) = svp(i,j,k,n)-whls(k) * (sv0(i,j,k,n) - sv0(i,j,k-1,n))/dzh(k)
+              end do
+            end do
+          end if
+        end if
+      end do
+    end do
+  end if
+  
+  !$acc wait
 
   return
   end subroutine lstend

--- a/src/modforces.f90
+++ b/src/modforces.f90
@@ -130,7 +130,7 @@ contains
 
   if (lcoriol .eqv. .false.) return
 
-  !$acc parallel loop collapse(3) default(present)
+  !$acc parallel loop collapse(3) default(present) async
   do k=2,kmax
     do j=2,j1
       do i=2,i1
@@ -155,7 +155,7 @@ contains
 !     --------------------------------------------
 !     special treatment for lowest full level: k=1
 !     --------------------------------------------
-  !$acc parallel loop collapse(2) default(present)
+  !$acc parallel loop collapse(2) default(present) async
   do j=2,j1
     do i=2,i1
 
@@ -171,7 +171,7 @@ contains
     end do
   end do
 !     ----------------------------------------------end i,j-loop
-
+  !$acc wait
   return
   end subroutine coriolis
 

--- a/src/modgenstat.f90
+++ b/src/modgenstat.f90
@@ -601,9 +601,6 @@ contains
     real    upcu, vpcv
     real    qls
 
-    !$acc update self(u0, v0, w0, um, vm, wm, qtm, thlm, thl0, qt0, qt0h, &
-    !$acc&            ql0, ql0h, thl0h, thv0h, sv0, svm, e12m, exnf, exnh, &
-    !$acc&            ustar, thlflux, qtflux, svflux)
   !-----------------------------------------------------------------------
   !     1.    INITIALISE LOCAL CONSTANTS
   !     --    --------------------------

--- a/src/modgenstat.f90
+++ b/src/modgenstat.f90
@@ -549,7 +549,9 @@ contains
 
     use modglobal, only : rk3step,timee,dt_lim
     use modtimer, only: timer_tic, timer_toc
+#if defined(_OPENACC)
     use modgpu, only: update_host
+#endif
     implicit none
     if (.not. lstat) return
     if (rk3step/=3) return
@@ -1149,6 +1151,7 @@ contains
       integer nsecs, nhrs, nminut,k,n
       real convt, convq
       character(40) :: name
+
       nsecs   = nint(rtimee)
       nhrs    = int(nsecs/3600)
       nminut  = int(nsecs/60)-nhrs*60

--- a/src/modgenstat.f90
+++ b/src/modgenstat.f90
@@ -563,6 +563,9 @@ contains
     if (timee>=tnext) then
       tnext = tnext+idtav
       call timer_tic("Do genstat")
+#if defined(_OPENACC)
+      call update_host
+#endif
       call do_genstat
       call timer_toc("Do genstat")
     end if

--- a/src/modgpu.f90
+++ b/src/modgpu.f90
@@ -125,5 +125,16 @@ contains
     !$acc enter data copyin(workspace)
   
   end subroutine allocate_workspace
+
+  !> @brief Deallocate GPU workspaces
+  subroutine deallocate_workspace
+    implicit none
+
+    integer, intent(in) :: n
+
+    !$acc exit data delete(workspace)
+    deallocate(workspace)
+
+  end subroutine deallocate_workspace
 #endif
 end module modgpu

--- a/src/modgpu.f90
+++ b/src/modgpu.f90
@@ -45,12 +45,12 @@ contains
     !$acc&              wfls, whls, thlpcar, dthldxls, dthldyls, &
     !$acc&              dthldtls, dqtdxls, dqtdyls, dqtdtls, &
     !$acc&              dudxls, dudyls, dudtls, dvdxls, dvdyls, &
-    !$acc&              dvdtls, dthvdz, qvsl, qvsi, esl, qsat)
+    !$acc&              dvdtls, dthvdz, qvsl, qvsi, esl, qsat, &
     !$acc&              dzf, dzh, zh, zf, delta, deltai, &
     !$acc&              z0m, z0h, obl, tskin, qskin, Cm, Cs, &
     !$acc&              ustar, dudz, dvdz, thlflux, qtflux, &
     !$acc&              dqtdz, dthldz, svflux, svs, horv, &
-    !$acc&              ekm, ekh, zlt, sbdiss, sbshr, sbbuo, csz &
+    !$acc&              ekm, ekh, zlt, sbdiss, sbshr, sbbuo, csz, &
     !$acc&              anis_fac, tsc, thlpcar, thlprad, presf, & 
     !$acc&              presh, exnf, exnh, rhof, &
     !$acc&              qvsl, qvsi, esl, qsat, &
@@ -60,23 +60,17 @@ contains
   
   !> @brief Copies data from GPU to host, mostly for debugging
   subroutine update_host
-    use modfields, only: um, vm, wm, thlm, e12m, qtm, &
-                         u0, v0, w0, thl0, thl0h, qt0h, e120, qt0, &
-                         up, vp, wp, thlp, e12p, qtp, &
-                         svm, sv0, svp, &
-                         rhobf, rhobh, &
-                         ql0, ql0h, tmp0, thv0h, dthvdz, &
-                         whls, ug, vg, thvf, thvh, &
-                         presf, presh,exnf, exnh, &
-                         rhof, &
-                         qt0av, ql0av, thl0av, u0av, v0av, &
-                         dpdxl, dpdyl, &
-                         dthldxls, dthldyls, dthldtls, &
-                         dqtdxls, dqtdyls, dqtdtls, &
-                         dudxls, dudyls, dudtls, &
-                         dvdxls, dvdyls, dvdtls, &
-                         thlpcar, sv0av, &
-                         qvsl, qvsi, esl, qsat
+    use modfields, only: um, u0, up, vm, v0, vp, wm, w0, wp, &
+                         thlm, thl0, thlp, qtm, qt0, qtp, &
+                         e12m, e120, e12p, svm, sv0, svp, &
+                         rhobf, rhobh, ql0, tmp0, ql0h, thv0h, &
+                         thl0h, qt0h, presf, presh, exnf, exnh, &
+                         thvh, thvf, rhof, qt0av, ql0av, thl0av, &
+                         u0av, v0av, sv0av, ug, vg, dpdxl, dpdyl, &
+                         wfls, whls, thlpcar, dthldxls, dthldyls, &
+                         dthldtls, dqtdxls, dqtdyls, dqtdtls, &
+                         dudxls, dudyls, dudtls, dvdxls, dvdyls, &
+                         dvdtls, dthvdz, qvsl, qvsi, esl, qsat
     use modglobal, only: dzf, dzh, zh, zf, delta, deltai, &
                          rd, rv, esatmtab, esatitab, esatltab
     use modsurfdata, only: z0m, z0h, obl, tskin, qskin, Cm, Cs, &
@@ -103,12 +97,12 @@ contains
     !$acc&            wfls, whls, thlpcar, dthldxls, dthldyls, &
     !$acc&            dthldtls, dqtdxls, dqtdyls, dqtdtls, &
     !$acc&            dudxls, dudyls, dudtls, dvdxls, dvdyls, &
-    !$acc&            dvdtls, dthvdz, qvsl, qvsi, esl, qsat)
+    !$acc&            dvdtls, dthvdz, qvsl, qvsi, esl, qsat, &
     !$acc&            dzf, dzh, zh, zf, delta, deltai, &
     !$acc&            z0m, z0h, obl, tskin, qskin, Cm, Cs, &
     !$acc&            ustar, dudz, dvdz, thlflux, qtflux, &
     !$acc&            dqtdz, dthldz, svflux, svs, horv, &
-    !$acc&            ekm, ekh, zlt, sbdiss, sbshr, sbbuo, csz &
+    !$acc&            ekm, ekh, zlt, sbdiss, sbshr, sbbuo, csz, &
     !$acc&            anis_fac, tsc, thlpcar, thlprad, presf, & 
     !$acc&            presh, exnf, exnh, rhof, &
     !$acc&            qvsl, qvsi, esl, qsat, &

--- a/src/modgpu.f90
+++ b/src/modgpu.f90
@@ -4,6 +4,7 @@ module modgpu
 
 save
   real(pois_r), allocatable, target :: workspace(:)
+  logical :: host_is_updated = .false.
 
 #if defined(_OPENACC)
 contains
@@ -130,14 +131,16 @@ contains
   end subroutine update_host
 
   !> @brief Allocate reusable workspace for transposes and FFT
-  subroutine allocate_workspace(nx, ny, nz)
+  subroutine allocate_workspace(n)
     implicit none
     
-    integer, intent(in) :: nx, ny, nz
+    integer, intent(in) :: n
 
-    allocate(workspace(nx*ny*nz))
+    allocate(workspace(n))
 
-    !$acc enter data create(workspace)
+    workspace = 0
+
+    !$acc enter data copyin(workspace)
   
   end subroutine allocate_workspace
 #endif

--- a/src/modgpu.f90
+++ b/src/modgpu.f90
@@ -10,23 +10,17 @@ save
 contains
   !> @brief Copies fields and arrays to GPU  
   subroutine update_gpu
-    use modfields, only: um, vm, wm, thlm, e12m, qtm, &
-                         u0, v0, w0, thl0, thl0h, qt0h, e120, qt0, &
-                         up, vp, wp, thlp, e12p, qtp, &
-                         svm, sv0, svp, &
-                         rhobf, rhobh, &
-                         ql0, ql0h, tmp0, thv0h, dthvdz, &
-                         whls, ug, vg, thvf, thvh, &
-                         presf, presh,exnf, exnh, &
-                         rhof, &
-                         qt0av, ql0av, thl0av, u0av, v0av, &
-                         dpdxl, dpdyl, &
-                         dthldxls, dthldyls, dthldtls, &
-                         dqtdxls, dqtdyls, dqtdtls, &
-                         dudxls, dudyls, dudtls, &
-                         dvdxls, dvdyls, dvdtls, &
-                         thlpcar, sv0av, &
-                         qvsl, qvsi, esl, qsat
+    use modfields, only: um, u0, up, vm, v0, vp, wm, w0, wp, &
+                         thlm, thl0, thlp, qtm, qt0, qtp, &
+                         e12m, e120, e12p, svm, sv0, svp, &
+                         rhobf, rhobh, ql0, tmp0, ql0h, thv0h, &
+                         thl0h, qt0h, presf, presh, exnf, exnh, &
+                         thvh, thvf, rhof, qt0av, ql0av, thl0av, &
+                         u0av, v0av, sv0av, ug, vg, dpdxl, dpdyl, &
+                         wfls, whls, thlpcar, dthldxls, dthldyls, &
+                         dthldtls, dqtdxls, dqtdyls, dqtdtls, &
+                         dudxls, dudyls, dudtls, dvdxls, dvdyls, &
+                         dvdtls, dthvdz, qvsl, qvsi, esl, qsat
     use modglobal, only: dzf, dzh, zh, zf, delta, deltai, &
                          rd, rv, esatmtab, esatitab, esatltab
     use modsurfdata, only: z0m, z0h, obl, tskin, qskin, Cm, Cs, &
@@ -41,29 +35,24 @@ contains
 
     implicit none
 
-    !$acc update device(um, vm, wm, thlm, e12m, qtm, &
-    !$acc&              u0, v0, w0, thl0, thl0h, qt0h, e120, qt0, &
-    !$acc&              up, vp, wp, thlp, e12p, qtp, &
-    !$acc&              svm, sv0, svp, &
-    !$acc&              rhobf, rhobh, &
-    !$acc&              ql0, ql0h, tmp0, thv0h, dthvdz, &
-    !$acc&              whls, ug, vg, &
-    !$acc&              thvf, thvh, &
-    !$acc&              qt0av, ql0av, thl0av, u0av, v0av, sv0av, &
-    !$acc&              dpdxl, dpdyl, &
-    !$acc&              dthldxls, dthldyls, dthldtls, &
-    !$acc&              dqtdxls, dqtdyls, dqtdtls, &
-    !$acc&              dudxls, dudyls, dudtls, &
-    !$acc&              dvdxls, dvdyls, dvdtls, &
+    !$acc update device(um, u0, up, vm, v0, vp, wm, w0, wp, &
+    !$acc&              thlm, thl0, thlp, qtm, qt0, qtp, &
+    !$acc&              e12m, e120, e12p, svm, sv0, svp, &
+    !$acc&              rhobf, rhobh, ql0, tmp0, ql0h, thv0h, &
+    !$acc&              thl0h, qt0h, presf, presh, exnf, exnh, &
+    !$acc&              thvh, thvf, rhof, qt0av, ql0av, thl0av, &
+    !$acc&              u0av, v0av, sv0av, ug, vg, dpdxl, dpdyl, &
+    !$acc&              wfls, whls, thlpcar, dthldxls, dthldyls, &
+    !$acc&              dthldtls, dqtdxls, dqtdyls, dqtdtls, &
+    !$acc&              dudxls, dudyls, dudtls, dvdxls, dvdyls, &
+    !$acc&              dvdtls, dthvdz, qvsl, qvsi, esl, qsat)
     !$acc&              dzf, dzh, zh, zf, delta, deltai, &
     !$acc&              z0m, z0h, obl, tskin, qskin, Cm, Cs, &
     !$acc&              ustar, dudz, dvdz, thlflux, qtflux, &
     !$acc&              dqtdz, dthldz, svflux, svs, horv, &
-    !$acc&              tsc, &
-    !$acc&              ekm, ekh, zlt, sbdiss, sbshr, sbbuo, csz, anis_fac, &
-    !$acc&              thlpcar, thlprad, &
-    !$acc&              presf, presh, exnf, exnh, &
-    !$acc&              rhof, &
+    !$acc&              ekm, ekh, zlt, sbdiss, sbshr, sbbuo, csz &
+    !$acc&              anis_fac, tsc, thlpcar, thlprad, presf, & 
+    !$acc&              presh, exnf, exnh, rhof, &
     !$acc&              qvsl, qvsi, esl, qsat, &
     !$acc&              esatmtab, esatitab, esatltab)
 
@@ -104,31 +93,26 @@ contains
 
     if (host_is_updated) return
 
-    !$acc update self(um, vm, wm, thlm, e12m, qtm, &
-    !$acc&              u0, v0, w0, thl0, thl0h, qt0h, e120, qt0, &
-    !$acc&              up, vp, wp, thlp, e12p, qtp, &
-    !$acc&              svm, sv0, svp, &
-    !$acc&              rhobf, rhobh, &
-    !$acc&              ql0, ql0h, tmp0, thv0h, dthvdz, &
-    !$acc&              whls, ug, vg, &
-    !$acc&              thvf, thvh, &
-    !$acc&              qt0av, ql0av, thl0av, u0av, v0av, sv0av, &
-    !$acc&              dpdxl, dpdyl, &
-    !$acc&              dthldxls, dthldyls, dthldtls, &
-    !$acc&              dqtdxls, dqtdyls, dqtdtls, &
-    !$acc&              dudxls, dudyls, dudtls, &
-    !$acc&              dvdxls, dvdyls, dvdtls, &
-    !$acc&              dzf, dzh, zh, zf, delta, deltai, &
-    !$acc&              z0m, z0h, obl, tskin, qskin, Cm, Cs, &
-    !$acc&              ustar, dudz, dvdz, thlflux, qtflux, &
-    !$acc&              dqtdz, dthldz, svflux, svs, horv, &
-    !$acc&              tsc, &
-    !$acc&              ekm, ekh, zlt, sbdiss, sbshr, sbbuo, csz, anis_fac, &
-    !$acc&              thlpcar, thlprad, &
-    !$acc&              presf, presh, exnf, exnh, &
-    !$acc&              rhof, &
-    !$acc&              qvsl, qvsi, esl, qsat, &
-    !$acc&              esatmtab, esatitab, esatltab)
+    !$acc update self(um, u0, up, vm, v0, vp, wm, w0, wp, &
+    !$acc&            thlm, thl0, thlp, qtm, qt0, qtp, &
+    !$acc&            e12m, e120, e12p, svm, sv0, svp, &
+    !$acc&            rhobf, rhobh, ql0, tmp0, ql0h, thv0h, &
+    !$acc&            thl0h, qt0h, presf, presh, exnf, exnh, &
+    !$acc&            thvh, thvf, rhof, qt0av, ql0av, thl0av, &
+    !$acc&            u0av, v0av, sv0av, ug, vg, dpdxl, dpdyl, &
+    !$acc&            wfls, whls, thlpcar, dthldxls, dthldyls, &
+    !$acc&            dthldtls, dqtdxls, dqtdyls, dqtdtls, &
+    !$acc&            dudxls, dudyls, dudtls, dvdxls, dvdyls, &
+    !$acc&            dvdtls, dthvdz, qvsl, qvsi, esl, qsat)
+    !$acc&            dzf, dzh, zh, zf, delta, deltai, &
+    !$acc&            z0m, z0h, obl, tskin, qskin, Cm, Cs, &
+    !$acc&            ustar, dudz, dvdz, thlflux, qtflux, &
+    !$acc&            dqtdz, dthldz, svflux, svs, horv, &
+    !$acc&            ekm, ekh, zlt, sbdiss, sbshr, sbbuo, csz &
+    !$acc&            anis_fac, tsc, thlpcar, thlprad, presf, & 
+    !$acc&            presh, exnf, exnh, rhof, &
+    !$acc&            qvsl, qvsi, esl, qsat, &
+    !$acc&            esatmtab, esatitab, esatltab)
 
     host_is_updated = .true.
 

--- a/src/modgpu.f90
+++ b/src/modgpu.f90
@@ -102,6 +102,8 @@ contains
 
     implicit none
 
+    if (host_is_updated) return
+
     !$acc update self(um, vm, wm, thlm, e12m, qtm, &
     !$acc&            u0, v0, w0, thl0, thl0h, qt0h, e120, qt0, &
     !$acc&            up, vp, wp, thlp, e12p, qtp, &
@@ -127,6 +129,8 @@ contains
     !$acc&            rhof, &
     !$acc&            qvsl, qvsi, esl, qsat, &
     !$acc&            esatmtab, esatitab, esatltab)
+
+    host_is_updated = .true.
 
   end subroutine update_host
 

--- a/src/modgpu.f90
+++ b/src/modgpu.f90
@@ -29,9 +29,9 @@ contains
                          qvsl, qvsi, esl, qsat
     use modglobal, only: dzf, dzh, zh, zf, delta, deltai, &
                          rd, rv, esatmtab, esatitab, esatltab
-    use modsurfdata, only: ustar, dudz, dvdz, &
-                           thlflux, qtflux, dqtdz, dthldz, &
-                           svflux, svs
+    use modsurfdata, only: z0m, z0h, obl, tskin, qskin, Cm, Cs, &
+                           ustar, dudz, dvdz, thlflux, qtflux, &
+                           dqtdz, dthldz, svflux, svs, horv
     use modsubgriddata, only: ekm, ekh, zlt, csz, anis_fac, &
                               sbdiss, sbshr, sbbuo
     use modradiation, only: thlprad
@@ -56,11 +56,11 @@ contains
     !$acc&              dudxls, dudyls, dudtls, &
     !$acc&              dvdxls, dvdyls, dvdtls, &
     !$acc&              dzf, dzh, zh, zf, delta, deltai, &
-    !$acc&              ustar, dudz, dvdz, &
-    !$acc&              thlflux, qtflux, dqtdz, dthldz, &
+    !$acc&              z0m, z0h, obl, tskin, qskin, Cm, Cs, &
+    !$acc&              ustar, dudz, dvdz, thlflux, qtflux, &
+    !$acc&              dqtdz, dthldz, svflux, svs, horv, &
     !$acc&              tsc, &
     !$acc&              ekm, ekh, zlt, sbdiss, sbshr, sbbuo, csz, anis_fac, &
-    !$acc&              svflux, &
     !$acc&              thlpcar, thlprad, &
     !$acc&              presf, presh, exnf, exnh, &
     !$acc&              rhof, &
@@ -90,9 +90,9 @@ contains
                          qvsl, qvsi, esl, qsat
     use modglobal, only: dzf, dzh, zh, zf, delta, deltai, &
                          rd, rv, esatmtab, esatitab, esatltab
-    use modsurfdata, only: ustar, dudz, dvdz, &
-                           thlflux, qtflux, dqtdz, dthldz, &
-                           svflux, svs
+    use modsurfdata, only: z0m, z0h, obl, tskin, qskin, Cm, Cs, &
+                           ustar, dudz, dvdz, thlflux, qtflux, &
+                           dqtdz, dthldz, svflux, svs, horv
     use modsubgriddata, only: ekm, ekh, zlt, csz, anis_fac, &
                               sbdiss, sbshr, sbbuo
     use modradiation, only: thlprad
@@ -105,30 +105,30 @@ contains
     if (host_is_updated) return
 
     !$acc update self(um, vm, wm, thlm, e12m, qtm, &
-    !$acc&            u0, v0, w0, thl0, thl0h, qt0h, e120, qt0, &
-    !$acc&            up, vp, wp, thlp, e12p, qtp, &
-    !$acc&            svm, sv0, svp, &
-    !$acc&            rhobf, rhobh, &
-    !$acc&            ql0, ql0h, tmp0, thv0h, dthvdz, &
-    !$acc&            whls, ug, vg, &
-    !$acc&            thvf, thvh, &
-    !$acc&            qt0av, ql0av, thl0av, u0av, v0av, sv0av, &
-    !$acc&            dpdxl, dpdyl, &
-    !$acc&            dthldxls, dthldyls, dthldtls, &
-    !$acc&            dqtdxls, dqtdyls, dqtdtls, &
-    !$acc&            dudxls, dudyls, dudtls, &
-    !$acc&            dvdxls, dvdyls, dvdtls, &
-    !$acc&            dzf, dzh, zh, zf, delta, deltai, &
-    !$acc&            ustar, dudz, dvdz, &
-    !$acc&            thlflux, qtflux, dqtdz, dthldz, &
-    !$acc&            tsc, &
-    !$acc&            ekm, ekh, zlt, sbdiss, sbshr, sbbuo, csz, anis_fac, &
-    !$acc&            svflux, &
-    !$acc&            thlpcar, thlprad, &
-    !$acc&            presf, presh, exnf, exnh, &
-    !$acc&            rhof, &
-    !$acc&            qvsl, qvsi, esl, qsat, &
-    !$acc&            esatmtab, esatitab, esatltab)
+    !$acc&              u0, v0, w0, thl0, thl0h, qt0h, e120, qt0, &
+    !$acc&              up, vp, wp, thlp, e12p, qtp, &
+    !$acc&              svm, sv0, svp, &
+    !$acc&              rhobf, rhobh, &
+    !$acc&              ql0, ql0h, tmp0, thv0h, dthvdz, &
+    !$acc&              whls, ug, vg, &
+    !$acc&              thvf, thvh, &
+    !$acc&              qt0av, ql0av, thl0av, u0av, v0av, sv0av, &
+    !$acc&              dpdxl, dpdyl, &
+    !$acc&              dthldxls, dthldyls, dthldtls, &
+    !$acc&              dqtdxls, dqtdyls, dqtdtls, &
+    !$acc&              dudxls, dudyls, dudtls, &
+    !$acc&              dvdxls, dvdyls, dvdtls, &
+    !$acc&              dzf, dzh, zh, zf, delta, deltai, &
+    !$acc&              z0m, z0h, obl, tskin, qskin, Cm, Cs, &
+    !$acc&              ustar, dudz, dvdz, thlflux, qtflux, &
+    !$acc&              dqtdz, dthldz, svflux, svs, horv, &
+    !$acc&              tsc, &
+    !$acc&              ekm, ekh, zlt, sbdiss, sbshr, sbbuo, csz, anis_fac, &
+    !$acc&              thlpcar, thlprad, &
+    !$acc&              presf, presh, exnf, exnh, &
+    !$acc&              rhof, &
+    !$acc&              qvsl, qvsi, esl, qsat, &
+    !$acc&              esatmtab, esatitab, esatltab)
 
     host_is_updated = .true.
 

--- a/src/modmpi.f90
+++ b/src/modmpi.f90
@@ -515,7 +515,7 @@ contains
   else
 
     ! Single processor, make sure the field is periodic
-    !$acc kernels default(present)
+    !$acc kernels default(present) async
     a(:,sy-jh:sy-1,:) = a(:,ey-jh+1:ey,:)
     a(:,ey+1:ey+jh,:) = a(:,sy:sy+jh-1,:)
     !$acc end kernels
@@ -549,7 +549,7 @@ contains
   else
 
     ! Single processor, make sure the field is periodic
-    !$acc kernels default(present)
+    !$acc kernels default(present) async
     a(sx-ih:sx-1,:,:) = a(ex-ih+1:ex,:,:)
     a(ex+1:ex+ih,:,:) = a(sx:sx+ih-1,:,:)
     !$acc end kernels
@@ -581,6 +581,7 @@ contains
     deallocate (recve, recvw)
 
   endif
+  !$acc wait
   end subroutine excjs_real64
 
   subroutine excjs_logical(a,sx,ex,sy,ey,sz,ez,ih,jh)

--- a/src/modmpi.f90
+++ b/src/modmpi.f90
@@ -147,6 +147,10 @@ save
   interface slabsum
     procedure :: slabsum_real32
     procedure :: slabsum_real64
+#if defined(_OPENACC)
+    procedure :: slabsum_real32_gpu
+    procedure :: slabsum_real64_gpu
+#endif
   end interface
 
 contains
@@ -344,9 +348,6 @@ contains
   end subroutine exitmpi
 
   subroutine excjs_real32(a,sx,ex,sy,ey,sz,ez,ih,jh)
-#if defined(_OPENACC)
-  use openacc
-#endif
   implicit none
   integer sx, ex, sy, ey, sz, ez, ih, jh
   real(real32) a(sx-ih:ex+ih, sy-jh:ey+jh, sz:ez)
@@ -359,18 +360,11 @@ contains
                                           , sends,recvs &
                                           , sende,recve &
                                           , sendw,recvw
-  ! Check if the data is on the gpu
-#if defined(_OPENACC)
-  logical :: is_present
-  is_present = acc_is_present(a)
-#endif
 
 ! Calulate buffer lengths
-  !$acc kernels default(present) if(is_present)
   xl = size(a,1)
   yl = size(a,2)
   zl = size(a,3)
-  !$acc end kernels 
 
 !   Calculate buffer size
   nssize = xl*jh*zl
@@ -404,7 +398,7 @@ contains
   else
 
     ! Single processor, make sure the field is periodic
-    !$acc kernels default(present) if(is_present)
+    !$acc kernels default(present) async
     a(:,sy-jh:sy-1,:) = a(:,ey-jh+1:ey,:)
     a(:,ey+1:ey+jh,:) = a(:,sy:sy+jh-1,:)
     !$acc end kernels
@@ -438,7 +432,7 @@ contains
   else
 
     ! Single processor, make sure the field is periodic
-    !$acc kernels default(present) if(is_present)
+    !$acc kernels default(present) async
     a(sx-ih:sx-1,:,:) = a(ex-ih+1:ex,:,:)
     a(ex+1:ex+ih,:,:) = a(sx:sx+ih-1,:,:)
     !$acc end kernels
@@ -466,9 +460,12 @@ contains
     deallocate (recve, recvw)
 
   endif
+
+  !$acc wait
+
   end subroutine excjs_real32
 
-  subroutine excjs_real64(a,sx,ex,sy,ey,sz,ez,ih,jh,on_gpu)
+  subroutine excjs_real64(a,sx,ex,sy,ey,sz,ez,ih,jh)
   implicit none
   integer sx, ex, sy, ey, sz, ez, ih, jh
   real(real64) a(sx-ih:ex+ih, sy-jh:ey+jh, sz:ez)
@@ -477,14 +474,10 @@ contains
   type(MPI_REQUEST) :: reqn, reqs, reqe, reqw
   type(MPI_REQUEST) :: reqrn, reqrs, reqre, reqrw
   integer nssize, ewsize
-  logical, optional :: on_gpu
   real(real64),allocatable, dimension(:) :: sendn,recvn &
                                           , sends,recvs &
                                           , sende,recve &
                                           , sendw,recvw
-  
-  ! Ad-hoc solution for startup and other routines that use host data
-  ! Specify on_gpu=.true. if halo exchange has to be done on the gpu
 
 ! Calulate buffer lengths
   xl = size(a,1)
@@ -590,7 +583,9 @@ contains
     deallocate (recve, recvw)
 
   endif
+
   !$acc wait
+
   end subroutine excjs_real64
 
   subroutine excjs_logical(a,sx,ex,sy,ey,sz,ez,ih,jh)
@@ -710,11 +705,7 @@ contains
   endif
   end subroutine excjs_logical
 
-
   subroutine slabsum_real32(aver,ks,kf,var,ib,ie,jb,je,kb,ke,ibs,ies,jbs,jes,kbs,kes)
-#if defined(_OPENACC)
-    use openacc
-#endif
     implicit none
 
     integer           :: ks,kf
@@ -724,42 +715,23 @@ contains
     real(real32)      :: averl(ks:kf)
     real(real32)      :: avers(ks:kf)
     integer           :: k
-#if defined(_OPENACC)
-    logical :: is_present
 
-    is_present = acc_is_present(var)
-#endif
-   !$acc enter data copyin(averl, avers) if(is_present)
-
-    !$acc kernels if(is_present)
     averl       = 0.
     avers       = 0.
-    !$acc end kernels
 
-    !$acc kernels if(is_present)
     do k=kbs,kes
       averl(k) = sum(var(ibs:ies,jbs:jes,k))
     enddo
-    !$acc end kernels
 
-    !$acc update self(averl) if(is_present)
     call MPI_ALLREDUCE(averl, avers, kf-ks+1,  MPI_REAL4, &
                        MPI_SUM, comm3d,mpierr)
-    !$acc update device(avers) if(is_present)
     
-    !$acc kernels if(is_present)
     aver = aver + avers
-    !$acc end kernels
-
-    !$acc exit data delete(averl, avers) if(is_present)
 
     return
   end subroutine slabsum_real32
 
   subroutine slabsum_real64(aver,ks,kf,var,ib,ie,jb,je,kb,ke,ibs,ies,jbs,jes,kbs,kes)
-#if defined(_OPENACC)
-    use openacc
-#endif
     implicit none
 
     integer           :: ks,kf
@@ -769,40 +741,70 @@ contains
     real(real64)      :: averl(ks:kf)
     real(real64)      :: avers(ks:kf)
     integer           :: k
-#if defined(_OPENACC)
-    logical :: is_present
 
-    is_present = acc_is_present(var)
-#endif
-
-    !$acc enter data copyin(averl, avers) if(is_present)
-
-    !$acc kernels default(present) if(is_present)
     averl       = 0.
     avers       = 0.
-    !$acc end kernels
     
-    !$acc kernels default(present) if(is_present)
     do k=kbs,kes
       averl(k) = sum(var(ibs:ies,jbs:jes,k))
     enddo
-    !$acc end kernels
 
-    !$acc update self(averl) if(is_present)
-    ! CUDA-aware MPI should figure out that it has to move data from the GPU
     call MPI_ALLREDUCE(averl, avers, kf-ks+1,  MPI_REAL8, &
                        MPI_SUM, comm3d,mpierr)
-    !$acc update device(avers) if(is_present)
 
-    !$acc kernels copy(aver) if(is_present)
     aver = aver + avers
-    !$acc end kernels
-
-    !$acc exit data delete(averl, avers) if(is_present)
 
     return
   end subroutine slabsum_real64
+#if defined(_OPENACC)
+  subroutine slabsum_real32_gpu(aver,ks,kf,var,ib,ie,jb,je,kb,ke,ibs,ies,jbs,jes,kbs,kes)
+    implicit none
 
+    integer :: ks, kf
+    integer :: ib, ie, jb, je, kb, ke, ibs, ies, jbs, jes, kbs, kes
+    real(real32), device :: aver(ks:kf)
+    real(real32), device :: var(ib:ie, jb:je, kb:ke)
+    real(real32) :: averl(ks:kf)
+    real(real32) :: avers(ks:kf)
+    integer :: k
+
+    if (nprocs == 1) then
+      ! Single processor, no need for MPI calls  
+
+      !$acc kernels default(present)
+      do k = kbs, kes
+        aver(k) = aver(k) + sum(var(ibs:ies, jbs:jes, k))
+      end do
+      !$acc end kernels
+    else
+      stop "The program should have stopped already"
+    end if
+  end subroutine slabsum_real32_gpu
+
+  subroutine slabsum_real64_gpu(aver,ks,kf,var,ib,ie,jb,je,kb,ke,ibs,ies,jbs,jes,kbs,kes)
+    implicit none
+
+    integer :: ks, kf
+    integer :: ib, ie, jb, je, kb, ke, ibs, ies, jbs, jes, kbs, kes
+    real(real64), device :: aver(ks:kf)
+    real(real64), device :: var(ib:ie, jb:je, kb:ke)
+    real(real64) :: averl(ks:kf)
+    real(real64) :: avers(ks:kf)
+    integer :: k
+
+    if (nprocs == 1) then
+      ! Single processor, no need for MPI calls  
+
+      !$acc kernels default(present)
+      do k = kbs, kes
+        aver(k) = aver(k) + sum(var(ibs:ies, jbs:jes, k))
+      end do
+      !$acc end kernels
+    else
+      stop "The program should have stopped already"
+    end if
+  end subroutine slabsum_real64_gpu
+#endif
   subroutine mpi_get_time(val)
    real(real32), intent(out) :: val
 

--- a/src/modmpi.f90
+++ b/src/modmpi.f90
@@ -246,6 +246,15 @@ contains
  ! if either nprocx = 0 or nprocy = 0 a value is computed automatically
  ! considering the total number of processors but not the itot,jtot grid size
     call MPI_COMM_SIZE( MPI_COMM_WORLD, nprocs, mpierr)
+
+#if defined(_OPENACC)
+    if (nprocs > 1) then
+      if (myid == 0) then
+        stop "GPU runs with more than 1 CPU are not supported yet!"
+      end if
+    end if
+#endif
+
     call checkmpierror(mpierr, 'MPI_COMM_SIZE')
 
     call MPI_DIMS_CREATE( nprocs, 2, dims, mpierr )

--- a/src/modmpi.f90
+++ b/src/modmpi.f90
@@ -765,26 +765,26 @@ contains
     is_present = acc_is_present(var)
 #endif
 
-   !$acc enter data copyin(averl, avers) if(is_present)
- 
-    !$acc kernels if(is_present)
+    !$acc enter data copyin(averl, avers) if(is_present)
+
+    !$acc kernels default(present) if(is_present)
     averl       = 0.
     avers       = 0.
     !$acc end kernels
     
-    !$acc kernels if(is_present)
+    !$acc kernels default(present) if(is_present)
     do k=kbs,kes
       averl(k) = sum(var(ibs:ies,jbs:jes,k))
     enddo
     !$acc end kernels
 
+    !$acc update self(averl) if(is_present)
     ! CUDA-aware MPI should figure out that it has to move data from the GPU
-    !$acc update host(averl) if(is_present)
     call MPI_ALLREDUCE(averl, avers, kf-ks+1,  MPI_REAL8, &
                        MPI_SUM, comm3d,mpierr)
     !$acc update device(avers) if(is_present)
 
-    !$acc kernels if(is_present)
+    !$acc kernels copy(aver) if(is_present)
     aver = aver + avers
     !$acc end kernels
 

--- a/src/modpois.f90
+++ b/src/modpois.f90
@@ -80,10 +80,9 @@ contains
     allocate(pup(2-ih:i1+ih,2-jh:j1+jh,kmax))
     allocate(pvp(2-ih:i1+ih,2-jh:j1+jh,kmax))
     allocate(pwp(2-ih:i1+ih,2-jh:j1+jh,k1))
-    !$acc enter data create(pup, pvp, pwp)
 
     allocate(a(kmax), b(kmax), c(kmax))
-    !$acc enter data create(a, b, c)
+    !$acc enter data create(pup, pvp, pwp, a, b, c)
 
   end subroutine initpois
 
@@ -104,6 +103,7 @@ contains
       call fftwexit(p,Fp,d,xyrt)
     else if (solver_id == 200) then
       call cufftexit(p, Fp, d, xyrt)
+      !$acc exit data delete(pup, pvp, pwp, a, b, c)
     else
       ! HYPRE based solver
       call fft2dexit(p,Fp,d,xyrt)

--- a/src/modpois.f90
+++ b/src/modpois.f90
@@ -426,39 +426,5 @@ contains
 
     !$acc wait
   end subroutine solmpj
-  
-  subroutine write_pointer(array)
-    implicit none
-    real, pointer, intent(in), dimension(:,:,:) :: array
-    integer :: i,j,k
-
-    do k=1, size(array, dim=3)
-      write(*,*) "k = ", k
-      do i=1, size(array, dim=1)
-        do j=1, size(array, dim=2)
-          write(*, ' (F10.4)', advance='no') array(i,j,k)
-        end do
-        write(*,*)
-      end do
-    end do
-  
-  end subroutine write_pointer
-
-  subroutine write_array(array)
-    implicit none
-    real, allocatable, intent(in), dimension(:,:,:) :: array
-    integer :: i,j,k
-
-    do k=1, size(array, dim=3)
-      write(*,*) "k = ", k
-      do i=1, size(array, dim=1)
-        do j=1, size(array, dim=2)
-          write(*, ' (F10.4)', advance='no') array(i,j,k)
-        end do
-        write(*,*)
-      end do
-    end do
-  
-  end subroutine write_array
 
 end module modpois

--- a/src/modpois.f90
+++ b/src/modpois.f90
@@ -192,7 +192,7 @@ contains
     ! TODO: allocate these in initpois
     rk3coef = rdt / (4. - dble(rk3step))
     
-    !$acc parallel loop collapse(3) default(present)
+    !$acc parallel loop collapse(3) default(present) async(1)
     do k=1,kmax
       do j=2,j1
         do i=2,i1
@@ -212,7 +212,7 @@ contains
 
   !**************************************************************
 
-    !$acc parallel loop collapse(2) default(present)
+    !$acc parallel loop collapse(2) default(present) async(1)
     do j=2,j1
       do i=2,i1
         pwp(i,j,1)  = 0.
@@ -223,7 +223,7 @@ contains
     call excjs(pup,2,i1,2,j1,1,kmax,ih,jh)
     call excjs(pvp,2,i1,2,j1,1,kmax,ih,jh)
 
-    !$acc parallel loop collapse(3) default(present)
+    !$acc parallel loop collapse(3) default(present) async(1)
     do k=1,kmax
       do j=2,j1
         do i=2,i1
@@ -233,6 +233,8 @@ contains
         end do
       end do
     end do
+
+    !$acc wait
 
   end subroutine fillps
 
@@ -274,7 +276,7 @@ contains
   ! **  pressure gradients.  ***************************************
   !*****************************************************************
 
-    !$acc parallel loop collapse(3) default(present) 
+    !$acc parallel loop collapse(3) default(present) async(1)
     do k=1,kmax
       do j=2,j1
         do i=2,i1
@@ -284,7 +286,7 @@ contains
       end do
     end do
 
-    !$acc parallel loop collapse(3) default(present)
+    !$acc parallel loop collapse(3) default(present) async(1)
     do k=2,kmax
       do j=2,j1
         do i=2,i1
@@ -292,6 +294,8 @@ contains
         end do
       end do
     end do
+
+    !$acc wait
 
     return
   end subroutine tderive

--- a/src/modquadrant.f90
+++ b/src/modquadrant.f90
@@ -288,6 +288,9 @@ contains
 !> General routine, does the timekeeping
   subroutine quadrant
     use modglobal, only : rk3step,timee,dt_lim
+#if defined(_OPENACC)
+    use modgpu, only: update_host
+#endif
     implicit none
     if(.not. lquadrant) return
     if (rk3step/=3) return
@@ -297,6 +300,9 @@ contains
     end if
     if (timee>=tnext) then
       tnext = tnext+idtav
+#if defined(_OPENACC)
+      call update_host
+#endif
       do isamp = 1,isamptot
         call doquadrant
       end do

--- a/src/modradfield.f90
+++ b/src/modradfield.f90
@@ -138,6 +138,9 @@ contains
 
   subroutine radfield
     use modglobal, only : rk3step,timee,dt_lim
+#if defined(_OPENACC)
+    use modgpu, only: update_host
+#endif
     implicit none
 
     if (.not. lradfield) return
@@ -149,6 +152,9 @@ contains
     end if
     if (timee>=tnext) then
       tnext = tnext+idtav
+#if defined(_OPENACC)
+      call update_host
+#endif
       call sample_radfield
     end if
     if (timee>=tnextwrite) then

--- a/src/modradiation.f90
+++ b/src/modradiation.f90
@@ -249,6 +249,7 @@ contains
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   subroutine exitradiation
     implicit none
+    !$acc exit data delete(thlprad)
     deallocate(thlprad,swd,swdir,swdif,swu,lwd,lwu,swdca,swuca,lwdca,lwuca,lwc)
     deallocate(SW_up_TOA, SW_dn_TOA,LW_up_TOA,LW_dn_TOA, &
                SW_up_ca_TOA,SW_dn_ca_TOA,LW_up_ca_TOA,LW_dn_ca_TOA)

--- a/src/modstartup.f90
+++ b/src/modstartup.f90
@@ -672,7 +672,9 @@ contains
       qtm  = qt0
       svm  = sv0
       e12m = e120
+      !$acc set device_type(host)
       call calc_halflev
+      !$acc set device_type(nvidia)
       exnf = (presf/pref0)**(rd/cp)
       exnh = (presh/pref0)**(rd/cp)
 
@@ -995,6 +997,9 @@ contains
   !  if trestart = 0, no periodic restart files will be written.
   subroutine writerestartfiles
     use modglobal, only : trestart,itrestart,tnextrestart,dt_lim,timee,timeleft,rk3step
+#if defined(_OPENACC)
+    use modgpu, only: update_host
+#endif
     implicit none
 
     if (timee == 0) return
@@ -1006,8 +1011,11 @@ contains
     ! if trestart = 0, write restart files only at the end of the simulation
     ! if trestart < 0, don't write any restart files
     if ((timee>=tnextrestart .and. trestart > 0) .or. (timeleft==0 .and. trestart >= 0)) then
-       tnextrestart = tnextrestart+itrestart
-       call do_writerestartfiles
+      tnextrestart = tnextrestart+itrestart
+#if defined(_OPENACC)
+      call update_host 
+#endif
+      call do_writerestartfiles
     end if
   end subroutine writerestartfiles
 

--- a/src/modsubgrid.f90
+++ b/src/modsubgrid.f90
@@ -64,8 +64,6 @@ contains
     ekm=0.; ekh=0.; zlt=0.; sbdiss=0.; sbshr=0.; sbbuo=0.; csz=0.
     anis_fac = 0.
 
-    !$acc enter data copyin(ekm, ekh, zlt, sbdiss, sbshr, sbbuo, csz, anis_fac)
-
     cm = cf / (2. * pi) * (1.5*alpha_kolm)**(-1.5)
 
 !     ch   = 2. * alpha_kolm / beta_kolm

--- a/src/modsubgrid.f90
+++ b/src/modsubgrid.f90
@@ -187,6 +187,8 @@ contains
 
   subroutine exitsubgrid
     implicit none
+    !$acc exit data delete(ekm, ekh, zlt, csz, anis_fac, &
+    !$acc&                 sbdiss, sbshr, sbbuo)
     deallocate(ekm,ekh,zlt,sbdiss,sbbuo,sbshr,csz,anis_fac)
   end subroutine exitsubgrid
 

--- a/src/modsurface.f90
+++ b/src/modsurface.f90
@@ -231,6 +231,7 @@ contains
       if (mod(itot,xpatches) .ne. 0) stop "NAMSURFACE: Not an integer amount of grid points per patch in the x-direction"
       if (mod(jtot,ypatches) .ne. 0) stop "NAMSURFACE: Not an integer amount of grid points per patch in the y-direction"
 
+      allocate(horvpatch(xpatches,ypatches))
       allocate(z0mav_patch(xpatches,ypatches))
       allocate(z0hav_patch(xpatches,ypatches))
       allocate(thls_patch(xpatches,ypatches))
@@ -674,6 +675,7 @@ contains
 
     ! 3. Initialize surface layer
     allocate(ustar   (i2,j2))
+    ustar_3D(1:i2, 1:j2, 1:1) => ustar
 
     allocate(dudz    (i2,j2))
     allocate(dvdz    (i2,j2))
@@ -686,6 +688,8 @@ contains
     allocate(svs(nsv))
     !$acc enter data create(ustar, dudz, dvdz)
     !$acc enter data create(thlflux, qtflux, dqtdz, dthldz, svflux, svs)
+
+    allocate(horv(2:i1,2:j1))
 
     if (lrsAgs) then
       allocate(AnField   (2:i1,2:j1))
@@ -713,38 +717,210 @@ contains
 
 !> Calculates the interaction with the soil, the surface temperature and humidity, and finally the surface fluxes.
   subroutine surface
-    use modglobal,  only : i1,j1,i2,j2,fkar,zf,cu,cv,nsv,ijtot,rd,rv,rtimee
-    use modfields,  only : thl0, qt0, u0, v0, u0av, v0av
-    use modmpi,     only : mpierr, comm3d, mpi_sum, excjs &
-                         , D_MPI_ALLREDUCE, D_MPI_BCAST
     use moduser,    only : surf_user
     implicit none
+    
+    select case (isurf)
+      case (1) ! Interactive land surface model
+        call calc_mean_wind
+        call getobl
+        call calc_drag_coefficients
+        call calc_aerodynamic_resistance
+        call do_lsm
+        call calc_friction_velocity
+        call calc_surface_flux
+        call calc_surface_gradients
+      case (2) ! Forced surface temperature, fluxes calculated
+        call calc_mean_wind
+        call getobl
+        call calc_drag_coefficients
+        call calc_aerodynamic_resistance
+        call presc_skin_temperature
+        call qtsurf
+        call calc_friction_velocity
+        call calc_surface_flux
+        call calc_surface_gradients
+      case (3) ! Forced fluxes, surface temperature calculated
+        call calc_mean_wind
+        call calc_drag_coefficients
+        call getobl
+        call presc_friction_velocity
+        call presc_surface_flux
+        call calc_surface_gradients
+        call calc_surface_scalars
+      case (4) ! Forced moisture and heat flux, u_star and surface temperature calculated
+        call calc_mean_wind
+        call calc_drag_coefficients
+        call getobl
+        call calc_friction_velocity
+        call presc_surface_flux
+        call calc_surface_gradients
+        call calc_surface_scalars
+      case (10) ! User defined surface scheme
+        call surf_user
+      case default
+        stop "Invalid option selected for isurf"
+    end select
 
-    integer  :: i, j, n, patchx, patchy
-    real     :: upcu, vpcv, horv, horvav, horvpatch(xpatches,ypatches)
-    real     :: upatch(xpatches,ypatches), vpatch(xpatches,ypatches)
-    real     :: Supatch(xpatches,ypatches), Svpatch(xpatches,ypatches)
-    integer  :: Npatch(xpatches,ypatches), SNpatch(xpatches,ypatches)
-    real     :: lthls_patch(xpatches,ypatches)
-    real     :: lqts_patch(xpatches,ypatches)!, qts_patch(xpatches,ypatches)
-    real     :: phimzf, phihzf
-    real     :: thlsl, qtsl
+  end subroutine surface
 
-    real     :: ust,ustl
-    real     :: wtsurfl, wqsurfl
-    real, pointer :: ustar_3D(:,:,:)
+  !> Calculates the drag coefficients \f$C_m\f$ and \f$C_s\f$
+  subroutine calc_drag_coefficients
+    use modglobal, only: i1, j1, fkar, zf, cu, cv
+    use modfields, only: u0, v0, u0av, v0av
+    implicit none
 
-    !$acc update self(u0, v0, thl0, qt0, u0av, v0av)
+    integer :: i, j
+    real :: upcu, vpcv
+   
+    do j = 2, j1
+      do i = 2, i1 
+        Cm(i,j) = fkar**2 / (log(zf(1) / z0m(i,j)) - psim(zf(1) / obl(i,j)) + psim(z0m(i,j) / obl(i,j)))**2 
+        Cs(i,j) = fkar**2 / (log(zf(1) / z0m(i,j)) - psim(zf(1) / obl(i,j)) + psim(z0m(i,j) / obl(i,j))) / &
+                  (log(zf(1) / z0h(i,j)) - psih(zf(1) / obl(i,j)) + psih(z0h(i,j) / obl(i,j)))
+      end do
+    end do
 
-    patchx = 0
-    patchy = 0
+  end subroutine calc_drag_coefficients
+  
+  !> Calculates the aerodynamic resistance \f$r_a\f$
+  subroutine calc_aerodynamic_resistance
+    use modglobal, only: i1, j1
+    implicit none
 
-    if (isurf==10) then
-      call surf_user
-      return
+    integer :: i, j 
+    integer :: patchx, patchy
+    
+    if (lmostlocal) then
+      do j = 2, j1
+        do i = 2, i1
+          ra(i,j) = 1. / (Cs(i,j) * horv(i,j))
+        end do
+      end do
+    else if (lhetero) then
+      do j = 2, j1
+        do i = 2, i1
+          patchx = patchxnr(i)
+          patchy = patchynr(j)
+          ra(i,j) = 1. / (Cs(i,j) * horvpatch(patchx, patchy))
+        end do
+      end do
+    else
+      do j = 2, j1
+        do i = 2, i1
+          ra(i,j) = 1. / (Cs(i,j) * horvav)
+        end do
+      end do
     end if
 
-    if(lhetero) then
+  end subroutine calc_aerodynamic_resistance
+
+  !> Prescribes the skin temperature
+  subroutine presc_skin_temperature
+    use modglobal, only: i1, j1
+    implicit none
+    
+    integer :: i, j
+
+    if (lhetero) then
+      do j = 2, j1
+        do i = 2, i1
+          tskin(i,j) = thls_patch(patchxnr(i), patchynr(j))
+        end do
+      end do
+    else
+      do j = 2, j1
+        do i = 2, i1
+          tskin(i,j) = thls
+        end do
+      end do
+    end if
+
+  end subroutine presc_skin_temperature
+
+  !> Calculates the surface temperature and specific humidity
+  subroutine calc_surface_scalars
+    use modglobal, only: i1, j1, rv, rd, ijtot
+    use modfields, only: thl0, qt0
+    use modmpi, only: D_MPI_ALLREDUCE, mpi_sum, comm3d, mpierr
+    implicit none
+
+    integer :: i, j
+    integer :: patchx, patchy
+    real :: thlsl, qtsl
+    real :: lthls_patch(xpatches, ypatches)
+    real :: lqts_patch(xpatches, ypatches)
+    integer :: Npatch(xpatches, ypatches), SNpatch(xpatches, ypatches)
+    
+    ! TODO: check if splitting these loops speeds things up on the GPU (async)
+    do j = 2, j1
+      do i = 2, i1
+        tskin(i,j) = min(max(thlflux(i,j) / (Cs(i,j) * horv(i,j)), -10.), 10.) + thl0(i,j,1) 
+        qskin(i,j) = min(max(qtflux(i,j) / (Cs(i,j) * horv(i,j)), -5.e-2), 5.e-2) + qt0(i,j,1)
+      end do
+    end do
+  
+    do j = 2, j1
+      do i = 2, i1
+        thlsl = thlsl + tskin(i,j)
+        qtsl = qtsl + qskin(i,j)
+      end do
+    end do
+
+    call D_MPI_ALLREDUCE(thlsl, thls, 1, MPI_SUM, comm3d, mpierr)
+    call D_MPI_ALLREDUCE(qtsl, qts, 1, MPI_SUM, comm3d, mpierr)
+
+    thls = thls / ijtot
+    qts = qts / ijtot
+    thvs = thls * (1. + (rv/rd - 1.) * qts)
+
+    if (lhetero) then
+      do j = 2, j1
+        do i = 2, i1
+          patchx = patchxnr(i)
+          patchy = patchynr(j)
+          lthls_patch(patchx, patchy) = lthls_patch(patchx, patchy) + tskin(i,j)
+          lqts_patch(patchx, patchy) = lqts_patch(patchx, patchy) + qskin(i,j)
+          Npatch(patchx, patchy) = Npatch(patchx, patchy) + 1
+        end do
+      end do
+      
+      call D_MPI_ALLREDUCE(lthls_patch(1:xpatches, 1:ypatches), thls_patch(1:xpatches, 1:ypatches), &
+                           xpatches*ypatches, MPI_SUM, comm3d, mpierr)
+      call D_MPI_ALLREDUCE(lqts_patch(1:xpatches, 1:ypatches), qts_patch(1:xpatches, 1:ypatches), &
+                           xpatches*ypatches, MPI_SUM, comm3d, mpierr)
+      call D_MPI_ALLREDUCE(Npatch(1:xpatches, 1:ypatches), SNpatch(1:xpatches, 1:ypatches), &
+                           xpatches*ypatches, MPI_SUM, comm3d, mpierr)
+      thls_patch = thls_patch / SNpatch
+      qts_patch = qts_patch / SNpatch
+      thvs_patch = thls_patch * (1. + (rv/rd - 1.) * qts_patch)
+    end if
+
+  end subroutine calc_surface_scalars
+  
+  !> Calculates the maginitude of the wind vector at the first level
+  subroutine calc_mean_wind
+    use modglobal, only: i1, j1, cu, cv
+    use modfields, only: u0, v0, u0av, v0av
+    use modmpi, only: D_MPI_ALLREDUCE, mpi_sum, comm3d, mpierr
+    implicit none
+    
+    integer :: i, j, patchx, patchy
+    real :: upcu, vpcv
+    real :: upatch(xpatches, ypatches), vpatch(xpatches, ypatches)
+    real :: Supatch(xpatches, ypatches), Svpatch(xpatches, ypatches)
+    integer :: Npatch(xpatches, ypatches), SNpatch(xpatches, ypatches)
+    
+    do j = 2, j1
+      do i = 2, i1
+        upcu = 0.5 * (u0(i,j,1) + u0(i+1,j,1)) + cu
+        vpcv = 0.5 * (v0(i,j,1) + v0(i,j+1,1)) + cv
+        horv(i,j) = sqrt(upcu**2. + vpcv**2.)
+        horv(i,j) = max(horv(i,j), 0.1)
+      end do
+    end do
+
+    if (lhetero) then
       upatch = 0
       vpatch = 0
       Npatch = 0
@@ -759,305 +935,240 @@ contains
         enddo
       enddo
 
-      call D_MPI_ALLREDUCE(upatch(1:xpatches,1:ypatches),Supatch(1:xpatches,1:ypatches),&
-      xpatches*ypatches,MPI_SUM, comm3d,mpierr)
-      call D_MPI_ALLREDUCE(vpatch(1:xpatches,1:ypatches),Svpatch(1:xpatches,1:ypatches),&
-      xpatches*ypatches,MPI_SUM, comm3d,mpierr)
-      call D_MPI_ALLREDUCE(Npatch(1:xpatches,1:ypatches),SNpatch(1:xpatches,1:ypatches),&
-      xpatches*ypatches,MPI_SUM, comm3d,mpierr)
+      call D_MPI_ALLREDUCE(upatch(1:xpatches, 1:ypatches), Supatch(1:xpatches, 1:ypatches), &
+                           xpatches*ypatches, MPI_SUM, comm3d, mpierr)
+      call D_MPI_ALLREDUCE(vpatch(1:xpatches, 1:ypatches), Svpatch(1:xpatches, 1:ypatches), &
+                           xpatches*ypatches, MPI_SUM, comm3d, mpierr)
+      call D_MPI_ALLREDUCE(Npatch(1:xpatches, 1:ypatches), SNpatch(1:xpatches, 1:ypatches), &
+                           xpatches*ypatches, MPI_SUM, comm3d, mpierr)
 
       horvpatch = sqrt(((Supatch/SNpatch) + cu) **2. + ((Svpatch/SNpatch) + cv) ** 2.)
       horvpatch = max(horvpatch, 0.1)
-    endif
+    else
+      horvav = sqrt(u0av(1)**2. + v0av(1)**2.)
+      horvav = max(horvav, 0.1)
+    end if
 
+  end subroutine calc_mean_wind
 
-    ! CvH start with computation of drag coefficients to allow for implicit solver
-    if(isurf <= 2) then
+  !> Calculates the friction velocity \f$u_*\f$
+  subroutine calc_friction_velocity
+    use modglobal, only: i1 ,j1
+    use modmpi, only: excjs
+    implicit none
 
-      if(lneutral) then
-        obl(:,:) = -1.e10
-        oblav    = -1.e10
-      else
-        call getobl
+    integer :: i, j
+
+    if (lmostlocal) then
+      do j = 2, j1
+        do i = 2, i1
+          ustar(i,j) = sqrt(Cm(i,j)) * horv(i,j)
+        end do
+      end do
+    else if (lhetero) then
+      do j = 2, j1
+        do i = 2, i1
+          ustar(i,j) = sqrt(Cm(i,j)) * horvpatch(patchxnr(i), patchynr(j))
+        end do
+      end do
+    else
+      do j = 2, j1
+        do i = 2, i1
+          ustar(i,j) = sqrt(Cm(i,j)) * horvav
+        end do
+      end do
+    end if
+
+    do j = 2, j1
+      do i = 2, i1
+        ustar(i,j) = max(ustar(i,j), 1.e-2)
+      end do
+    end do
+
+    call excjs(ustar_3D, 2, i1, 2, j1, 1, 1, 1, 1)
+      
+  end subroutine calc_friction_velocity
+
+  !> Prescribes the friction velocity \f$u_*\f$
+  subroutine presc_friction_velocity
+    use modglobal, only: i1, j1
+    use modmpi, only: excjs
+    implicit none 
+
+    integer :: i, j
+    
+    if (lhetero) then
+      do j = 2, j1
+        do i = 2, i1      
+          ustar(i,j) = ustin_patch(patchxnr(i), patchynr(j))
+        end do
+      end do
+    else
+      do j = 2, j1
+        do i = 2, i1
+          ustar(i,j) = ustin
+        end do
+      end do
+    end if
+
+    do j = 2, j1
+      do i = 2, i1
+        ustar(i,j) = max(ustar(i,j), 1.e-2)
+      end do
+    end do
+    
+    call excjs(ustar_3D, 2, i1, 2, j1, 1, 1, 1, 1)
+
+  end subroutine presc_friction_velocity
+
+  !> Calculates the surfaces fluxes using the scalar values at the surface and
+  !> the calculated aerodynamic resistance
+  subroutine calc_surface_flux
+    use modglobal, only: i1, j1, nsv, ijtot
+    use modfields, only: thl0, qt0 
+    use modmpi, only: D_MPI_ALLREDUCE, mpi_sum, comm3d, mpierr
+    implicit none
+
+    integer :: i, j, n
+    real :: ust, ustl, wtsurfl, wqsurfl
+
+    ! Uniform sensible and latent heat flux
+    if (lsmoothflux) then
+      ustl = sum(ustar(2:i1,2:j1))
+      wtsurfl = sum(thlflux(2:i1,2:j1))
+      wqsurfl = sum(qtflux(2:i1,2:j1))
+
+      call D_MPI_ALLREDUCE(ustl, ust, 1, MPI_SUM, comm3d, mpierr)
+      call D_MPI_ALLREDUCE(wtsurfl, wtsurf, 1, MPI_SUM, comm3d, mpierr)
+      call D_MPI_ALLREDUCE(wqsurfl, wqsurf, 1, MPI_SUM, comm3d, mpierr)
+      
+      ust = ust / ijtot
+      wtsurf = wtsurf / ijtot
+      wqsurf = wqsurf / ijtot
+
+      call presc_surface_flux
+    else
+      do j = 2, j1
+        do i = 2, i1
+          thlflux(i,j) = - (thl0(i,j,1) - tskin(i,j)) / ra(i,j)
+        end do
+      end do
+
+      do j = 2, j1    
+        do i = 2, i1
+          qtflux(i,j) = - (qt0(i,j,1) - qskin(i,j)) / ra(i,j)
+        end do
+      end do
+
+      ! Passive scalars
+      if (nsv > 0) then
+        if (lhetero) then
+          do n = 1, nsv
+            do j = 2, j1 
+              do i = 2, i1
+                svflux(i,j,n) = wsv_patch(n, patchxnr(i), patchynr(j))
+              end do
+            end do
+          end do
+        else
+          do n = 1, nsv
+            do j = 2, j1 
+              do i = 2, i1
+                svflux(i,j,n) = wsvsurf(n)
+              end do
+            end do
+          end do
+        end if
       end if
 
-      call D_MPI_BCAST(oblav ,1 ,0,comm3d,mpierr)
-
-      do j = 2, j1
-        do i = 2, i1
-          if(lhetero) then
-            patchx = patchxnr(i)
-            patchy = patchynr(j)
-          endif
-
-          ! 3     -   Calculate the drag coefficient and aerodynamic resistance
-          Cm(i,j) = fkar ** 2. / (log(zf(1) / z0m(i,j)) - psim(zf(1) / obl(i,j)) + psim(z0m(i,j) / obl(i,j))) ** 2.
-          Cs(i,j) = fkar ** 2. / (log(zf(1) / z0m(i,j)) - psim(zf(1) / obl(i,j)) + psim(z0m(i,j) / obl(i,j))) / &
-          (log(zf(1) / z0h(i,j)) - psih(zf(1) / obl(i,j)) + psih(z0h(i,j) / obl(i,j)))
-
-          if(lmostlocal) then
-            upcu  = 0.5 * (u0(i,j,1) + u0(i+1,j,1)) + cu
-            vpcv  = 0.5 * (v0(i,j,1) + v0(i,j+1,1)) + cv
-            horv  = sqrt(upcu ** 2. + vpcv ** 2.)
-            horv  = max(horv, 0.1)
-            ra(i,j) = 1. / ( Cs(i,j) * horv )
-          else
-            if (lhetero) then
-              ra(i,j) = 1. / ( Cs(i,j) * horvpatch(patchx,patchy) )
-            else
-              horvav  = sqrt(u0av(1) ** 2. + v0av(1) ** 2.)
-              horvav  = max(horvav, 0.1)
-              ra(i,j) = 1. / ( Cs(i,j) * horvav )
-            endif
-          end if
-
-        end do
-      end do
+      if (lCO2Ags) then
+        do n = 1, indCO2
+          do j = 2, j1
+            do i = 2, i1
+              svflux(i,j,n) = CO2flux(i,j)
+            end do
+          end do
+        end do 
+      end if
     end if
 
-    ! Solve the surface energy balance and the heat and moisture transport in the soil
-    if(isurf == 1) then
-      call do_lsm
+  end subroutine calc_surface_flux
 
-    elseif(isurf == 2) then
+  !> Prescribes the surface fluxes
+  subroutine presc_surface_flux
+    use modglobal, only: i1, j1, nsv
+    implicit none
+
+    integer :: i, j, n
+
+    if (lhetero) then
       do j = 2, j1
         do i = 2, i1
-          if(lhetero) then
-            tskin(i,j) = thls_patch(patchxnr(i),patchynr(j))
-          else
-            tskin(i,j) = thls
-          endif
+          thlflux(i,j) = wt_patch(patchxnr(i), patchynr(j))
+          qtflux(i,j) = wq_patch(patchxnr(i), patchynr(j))
         end do
       end do
 
-      call qtsurf
-
-    end if
-
-    ! 2     -   Calculate the surface fluxes
-    if( (i_expemis .gt. 0) .and. (i_expemis .le. nsv) ) then
-      wsvsurf(i_expemis) = expemis0 * exp(-(0.5*((rtimee-expemis1)/expemis2)**2.))
-      if(lhetero) wsv_patch(i_expemis,:,:) = wsvsurf(i_expemis)
-    endif
-
-    if(isurf <= 2) then
-      do j = 2, j1
-        do i = 2, i1
-          upcu   = 0.5 * (u0(i,j,1) + u0(i+1,j,1)) + cu
-          vpcv   = 0.5 * (v0(i,j,1) + v0(i,j+1,1)) + cv
-          horv   = sqrt(upcu ** 2. + vpcv ** 2.)
-          horv   = max(horv, 0.1)
-          horvav = sqrt(u0av(1) ** 2. + v0av(1) ** 2.)
-          horvav = max(horvav, 0.1)
-
-          if(lhetero) then
-            patchx = patchxnr(i)
-            patchy = patchynr(j)
-          endif
-
-          if(lmostlocal) then
-            ustar  (i,j) = sqrt(Cm(i,j)) * horv
-          else
-            if(lhetero) then
-              ustar  (i,j) = sqrt(Cm(i,j)) * horvpatch(patchx,patchy)
-            else
-              ustar  (i,j) = sqrt(Cm(i,j)) * horvav
-            endif
-          end if
-
-          thlflux(i,j) = - ( thl0(i,j,1) - tskin(i,j) ) / ra(i,j)
-          qtflux(i,j) = - (qt0(i,j,1)  - qskin(i,j)) / ra(i,j)
-
-          if(lhetero) then
-            do n=1,nsv
-              svflux(i,j,n) = wsv_patch(n,patchx,patchy)
-            enddo
-          else
-            do n=1,nsv
-              svflux(i,j,n) = wsvsurf(n)
-            enddo
-          endif
-
-          if(lCO2Ags) svflux(i,j,indCO2) = CO2flux(i,j)
-
-          phimzf = phim(zf(1)/obl(i,j))
-          phihzf = phih(zf(1)/obl(i,j))
-          
-          dudz  (i,j) = ustar(i,j) * phimzf / (fkar*zf(1))*(upcu/horv)
-          dvdz  (i,j) = ustar(i,j) * phimzf / (fkar*zf(1))*(vpcv/horv)
-          dthldz(i,j) = - thlflux(i,j) / ustar(i,j) * phihzf / (fkar*zf(1))
-          dqtdz (i,j) = - qtflux(i,j)  / ustar(i,j) * phihzf / (fkar*zf(1))
-        end do
-      end do
-
-      if(lsmoothflux) then
-
-        ustl    = sum(ustar  (2:i1,2:j1))
-        wtsurfl = sum(thlflux(2:i1,2:j1))
-        wqsurfl = sum(qtflux (2:i1,2:j1))
-
-        call D_MPI_ALLREDUCE(ustl  ,  ust   , 1, MPI_SUM, comm3d,mpierr)
-        call D_MPI_ALLREDUCE(wtsurfl, wtsurf, 1, MPI_SUM, comm3d,mpierr)
-        call D_MPI_ALLREDUCE(wqsurfl, wqsurf, 1, MPI_SUM, comm3d,mpierr)
-
-        wtsurf = wtsurf / ijtot
-        wqsurf = wqsurf / ijtot
-
-        do j = 2, j1
-          do i = 2, i1
-
-            thlflux(i,j) = wtsurf
-            qtflux (i,j) = wqsurf
-
-            do n=1,nsv
-              svflux(i,j,n) = wsvsurf(n)
-            enddo
-
-            phimzf = phim(zf(1)/obl(i,j))
-            phihzf = phih(zf(1)/obl(i,j))
-            
-            upcu  = 0.5 * (u0(i,j,1) + u0(i+1,j,1)) + cu
-            vpcv  = 0.5 * (v0(i,j,1) + v0(i,j+1,1)) + cv
-            horv  = sqrt(upcu ** 2. + vpcv ** 2.)
-            horv  = max(horv, 0.1)
-
-            dudz  (i,j) = ustar(i,j) * phimzf / (fkar*zf(1))*(upcu/horv)
-            dvdz  (i,j) = ustar(i,j) * phimzf / (fkar*zf(1))*(vpcv/horv)
-            dthldz(i,j) = - thlflux(i,j) / ustar(i,j) * phihzf / (fkar*zf(1))
-            dqtdz (i,j) = - qtflux(i,j)  / ustar(i,j) * phihzf / (fkar*zf(1))
+      if (nsv > 0) then
+        do n = 1, nsv
+          do j = 2, j1
+            do i = 2, i1
+              svflux(i,j,n) = wsv_patch(n, patchxnr(i), patchynr(j))
+            end do
           end do
         end do
-
       end if
-
-    else
-
-      if(lneutral) then
-        obl(:,:) = -1.e10
-        oblav    = -1.e10
-      else
-        call getobl
-      end if
-
-      thlsl = 0.
-      qtsl  = 0.
-
-      if(lhetero) then
-        lthls_patch = 0.0
-        lqts_patch  = 0.0
-        Npatch      = 0
-      endif
-
+    else 
       do j = 2, j1
         do i = 2, i1
-          if(lhetero) then
-            patchx = patchxnr(i)
-            patchy = patchynr(j)
-          endif
-
-          upcu   = 0.5 * (u0(i,j,1) + u0(i+1,j,1)) + cu
-          vpcv   = 0.5 * (v0(i,j,1) + v0(i,j+1,1)) + cv
-          horv   = sqrt(upcu ** 2. + vpcv ** 2.)
-          horv   = max(horv, 0.1)
-          horvav = sqrt(u0av(1) ** 2. + v0av(1) ** 2.)
-          horvav = max(horvav, 0.1)
-          if( isurf == 4) then
-            if(lmostlocal) then
-              ustar (i,j) = fkar * horv  / (log(zf(1) / z0m(i,j)) - psim(zf(1) / obl(i,j)) + psim(z0m(i,j) / obl(i,j)))
-            else
-              if(lhetero) then
-                ustar (i,j) = fkar * horvpatch(patchx,patchy) / (log(zf(1) / z0m(i,j)) - psim(zf(1) / obl(i,j))&
-                + psim(z0m(i,j) / obl(i,j)))
-              else
-                ustar (i,j) = fkar * horvav / (log(zf(1) / z0m(i,j)) - psim(zf(1) / obl(i,j)) + psim(z0m(i,j) / obl(i,j)))
-              endif
-            end if
-          else
-            if(lhetero) then
-              ustar (i,j) = ustin_patch(patchx,patchy)
-            else
-              ustar (i,j) = ustin
-            endif
-          end if
-
-          ustar  (i,j) = max(ustar(i,j), 1.e-2)
-          if(lhetero) then
-            thlflux(i,j) = wt_patch(patchx,patchynr(j))
-            qtflux (i,j) = wq_patch(patchx,patchynr(j))
-          else
-            thlflux(i,j) = wtsurf
-            qtflux (i,j) = wqsurf
-          endif
-
-          if(lhetero) then
-            do n=1,nsv
-              svflux(i,j,n) = wsv_patch(n,patchx,patchynr(j))
-            enddo
-          else
-            do n=1,nsv
-              svflux(i,j,n) = wsvsurf(n)
-            enddo
-          endif
-         
-          phimzf = phim(zf(1)/obl(i,j))
-          phihzf = phih(zf(1)/obl(i,j))
-          
-          dudz  (i,j) = ustar(i,j) * phimzf / (fkar*zf(1))*(upcu/horv)
-          dvdz  (i,j) = ustar(i,j) * phimzf / (fkar*zf(1))*(vpcv/horv)
-          dthldz(i,j) = - thlflux(i,j) / ustar(i,j) * phihzf / (fkar*zf(1))
-          dqtdz (i,j) = - qtflux(i,j)  / ustar(i,j) * phihzf / (fkar*zf(1))
-
-          Cs(i,j) = fkar ** 2. / ((log(zf(1) / z0m(i,j)) - psim(zf(1) / obl(i,j)) + psim(z0m(i,j) / obl(i,j))) * &
-          (log(zf(1) / z0h(i,j)) - psih(zf(1) / obl(i,j)) + psih(z0h(i,j) / obl(i,j))))
-
-          tskin(i,j) = min(max(thlflux(i,j) / (Cs(i,j) * horv),-10.),10.)  + thl0(i,j,1)
-          qskin(i,j) = min(max( qtflux(i,j) / (Cs(i,j) * horv),-5e-2),5e-2) + qt0(i,j,1)
-
-          thlsl      = thlsl + tskin(i,j)
-          qtsl       = qtsl  + qskin(i,j)
-          if (lhetero) then
-            lthls_patch(patchx,patchy) = lthls_patch(patchx,patchy) + tskin(i,j)
-            lqts_patch(patchx,patchy)  = lqts_patch(patchx,patchy)  + qskin(i,j)
-            Npatch(patchx,patchy)      = Npatch(patchx,patchy)      + 1
-          endif
+          thlflux(i,j) = wtsurf
+          qtflux(i,j) = wqsurf
         end do
       end do
 
-      call D_MPI_ALLREDUCE(thlsl, thls, 1, MPI_SUM, comm3d,mpierr)
-      call D_MPI_ALLREDUCE(qtsl , qts , 1, MPI_SUM, comm3d,mpierr)
-
-      thls = thls / ijtot
-      qts  = qts  / ijtot
-      thvs = thls * (1. + (rv/rd - 1.) * qts)
-
-      if (lhetero) then
-        call D_MPI_ALLREDUCE(lthls_patch(1:xpatches,1:ypatches), thls_patch(1:xpatches,1:ypatches),&
-        xpatches*ypatches, MPI_SUM, comm3d,mpierr)
-        call D_MPI_ALLREDUCE(lqts_patch(1:xpatches,1:ypatches),  qts_patch(1:xpatches,1:ypatches),&
-        xpatches*ypatches, MPI_SUM, comm3d,mpierr)
-        call D_MPI_ALLREDUCE(Npatch(1:xpatches,1:ypatches)     , SNpatch(1:xpatches,1:ypatches),&
-        xpatches*ypatches, MPI_SUM, comm3d,mpierr)
-        thls_patch = thls_patch / SNpatch
-        qts_patch  = qts_patch  / SNpatch
-        thvs_patch = thls_patch * (1. + (rv/rd - 1.) * qts_patch)
-      endif
-
-    !if (lhetero) then
-    !  thvs_patch = thls_patch * (1. + (rv/rd - 1.) * qts_patch)
-    !endif
-      !call qtsurf
-
+      if (nsv > 0) then
+        do n = 1, nsv
+          do j = 2, j1
+            do i = 2, i1
+              svflux(i,j,n) = wsvsurf(n)
+            end do
+          end do
+        end do
+      end if
     end if
+  end subroutine presc_surface_flux
+  
+  !> Calculates the surface gradients
+  subroutine calc_surface_gradients
+    use modglobal, only: i1, j1, cu, cv, zf, fkar
+    use modfields, only: u0, v0 
+    implicit none 
 
-    !$acc update device(ustar, dudz, dvdz)
-    !$acc update device(thlflux, qtflux, dqtdz, dthldz)
-    !$acc update device(svflux, svs)
+    integer :: i, j
+    real :: upcu, vpcv
+    real :: phimzf, phihzf
 
-    ! Transfer ustar to neighbouring cells, do this like a 3D field
-    ustar_3D(1:i2,1:j2,1:1) => ustar
-    call excjs(ustar_3D,2,i1,2,j1,1,1,1,1)
+    ! Momentum fluxes
+    do j = 2, j1
+      do i = 2, i1
+        upcu = 0.5 * (u0(i,j,1) + u0(i+1,j,1)) + cu
+        vpcv = 0.5 * (v0(i,j,1) + v0(i,j+1,1)) + cv
+        phimzf = phim(zf(1) / obl(i,j))
+        dudz(i,j) = ustar(i,j) * phimzf / (fkar * zf(1)) * (upcu / horv(i,j))
+        dvdz(i,j) = ustar(i,j) * phimzf / (fkar * zf(1)) * (vpcv / horv(i,j))
+      end do
+    end do
 
-  end subroutine surface
+    ! Scalar fluxes
+    do j = 2, j1
+      do i = 2, i1
+        phihzf = phih(zf(1) / obl(i,j))
+        dthldz(i,j) = - thlflux(i,j) / ustar(i,j) * phihzf / (fkar * zf(1))
+        dqtdz(i,j) = - qtflux(i,j) / ustar(i,j) * phihzf / (fkar * zf(1))
+      end do
+    end do
+
+  end subroutine calc_surface_gradients
 
 !> Calculate the surface humidity assuming saturation.
   subroutine qtsurf
@@ -1128,7 +1239,8 @@ contains
   subroutine getobl
     use modglobal, only : zf, rv, rd, grav, i1, j1, i2, j2, cu, cv
     use modfields, only : thl0av, qt0av, u0, v0, thl0, qt0, u0av, v0av
-    use modmpi,    only : mpierr,comm3d,mpi_sum,D_MPI_ALLREDUCE
+    use modmpi,    only : mpierr,comm3d,mpi_sum,D_MPI_ALLREDUCE, &
+                          D_MPI_BCAST
     implicit none
 
     integer             :: i,j,iter,patchx,patchy
@@ -1144,6 +1256,12 @@ contains
     real                :: loblpatch(xpatches,ypatches)
 
     !$acc update self(thl0av, qt0av)
+
+    if (lneutral) then
+      obl(:,:) = -1.e10
+      oblav = -1.e10
+      return
+    endif
 
     if(lmostlocal) then
 
@@ -1347,6 +1465,8 @@ contains
        end if
     end if
     oblav = L
+
+    call D_MPI_BCAST(oblav, 1, 0, comm3d, mpierr)
 
     return
   end subroutine getobl

--- a/src/modsurfdata.f90
+++ b/src/modsurfdata.f90
@@ -219,6 +219,7 @@ SAVE
   real, allocatable :: Cm    (:,:)            !<  Drag coefficient for momentum [-]
   real, allocatable :: Cs    (:,:)            !<  Drag coefficient for scalars [-]
   real, allocatable, target :: ustar (:,:)    !<  Friction velocity [m/s]
+  real, pointer     :: ustar_3D(:,:,:)        !<  Pointer for halo exchange
   real, allocatable :: thlflux (:,:)          !<  Kinematic temperature flux [K m/s]
   real, allocatable :: qtflux  (:,:)          !<  Kinematic specific humidity flux [kg/kg m/s]
   real, allocatable :: svflux  (:,:,:)        !<  Kinematic scalar flux [- m/s]
@@ -278,6 +279,9 @@ SAVE
   real              :: rsisurf2_land(max_lands)    = 0  !< Vegetation resistance [s/m] if isurf2 is used
   real, allocatable :: albedo_patch(:,:)                !< Albedo
   real              :: albedo_land(max_lands)      = -1 !< Albedo
+  real, allocatable :: horv(:,:)                        !< Horizontal wind velocity [m/s]
+  real, allocatable :: horvpatch(:,:)                   !< Horizontal wind velocity [m/s]
+  real              :: horvav                           !< Horizontal wind velocity [m/s]
   real, allocatable :: tsoil_patch(:,:,:)               !< Soil temperature [K]
   real, allocatable :: tsoildeep_patch(:,:)             !< Soil temperature [K]
   real, allocatable :: phiw_patch(:,:,:)                !<

--- a/src/modthermodynamics.f90
+++ b/src/modthermodynamics.f90
@@ -96,8 +96,10 @@ contains
     !$acc kernels default(present) async
     thvh=0.
     !$acc end kernels
-
+    
+    !$acc host_data use_device(thvh, thv0h)
     call slabsum(thvh,1,k1,thv0h,2-ih,i1+ih,2-jh,j1+jh,1,k1,2,i1,2,j1,1,k1) ! redefine halflevel thv using calculated thv
+    !$acc end host_data
 
     !$acc kernels default(present) async
     thvh = thvh/ijtot
@@ -118,7 +120,9 @@ contains
     thvf = 0.0
     !$acc end kernels
 
+    !$acc host_data use_device(thvf, thv0)
     call slabsum(thvf,1,k1,thv0,2-ih,i1+ih,2-jh,j1+jh,1,k1,2,i1,2,j1,1,k1)
+    !$acc end host_data
 
     !$acc kernels default(present) async
     thvf = thvf/ijtot
@@ -295,6 +299,8 @@ contains
     !$acc end kernels
 
 !  !CvH changed momentum array dimensions to same value as scalars!
+   !$acc host_data use_device(u0av, u0, v0av, v0, thl0av, thl0, qt0av, qt0, &
+   !$acc&                     ql0av, ql0, sv0av, sv0)
    call slabsum(u0av  ,1,k1,u0  ,2-ih,i1+ih,2-jh,j1+jh,1,k1,2,i1,2,j1,1,k1)
    call slabsum(v0av  ,1,k1,v0  ,2-ih,i1+ih,2-jh,j1+jh,1,k1,2,i1,2,j1,1,k1)
    call slabsum(thl0av,1,k1,thl0,2-ih,i1+ih,2-jh,j1+jh,1,k1,2,i1,2,j1,1,k1)
@@ -303,6 +309,7 @@ contains
    do n=1,nsv
       call slabsum(sv0av(1:1,n),1,k1,sv0(:,:,:,n),2-ih,i1+ih,2-jh,j1+jh,1,k1,2,i1,2,j1,1,k1)
    end do
+   !$acc end host_data
 
    !$acc kernels default(present) async(1)
    u0av   = u0av  /ijtot + cu
@@ -418,7 +425,6 @@ contains
 
 !     2: higher levels
 
-  ! TODO: see if a parallel loop with an atomic update is faster here
   !$acc serial loop default(present) async(1)
   do k=2,k1
     thvh(k)  = thetah(k)*(1+(rv/rd-1)*qth(k)-rv/rd*qlh(k))

--- a/src/modthermodynamics.f90
+++ b/src/modthermodynamics.f90
@@ -188,7 +188,7 @@ contains
 
             dthv = del_thv_dry
 
-            if  (ql0(i,j,k)> 0) then  !include moist thermodynamics
+            !if  (ql0(i,j,k)> 0) then  !include moist thermodynamics
 
                temp = thl0(i,j,k)*exnf(k)+(rlv/cp)*ql0(i,j,k)
                qs   = qt0(i,j,k) - ql0(i,j,k)
@@ -206,7 +206,7 @@ contains
                if (chi < chi_sat) then  !mixed parcel is saturated
                  dthv = del_thv_sat
               end if
-            end if
+            !end if
 
             dthvdz(i,j,k) = dthv/(dzh(k+1)+dzh(k))
           end do
@@ -417,7 +417,7 @@ contains
 
 !     1: lowest level: use first level value for safety!
 
-  !$acc serial default(present) async(1)
+  !$acc serial default(present) async(2) wait(1)
   thvh(1) = th0av(1)*(1+(rv/rd-1)*qt0av(1)-rv/rd*ql0av(1))
   presf(1) = ps**rdocp - grav*(pref0**rdocp)*zf(1) /(cp*thvh(1))
   presf(1) = presf(1)**(1./rdocp)
@@ -425,7 +425,7 @@ contains
 
 !     2: higher levels
 
-  !$acc serial loop default(present) async(1)
+  !$acc serial loop default(present) async(2) wait(1)
   do k=2,k1
     thvh(k)  = thetah(k)*(1+(rv/rd-1)*qth(k)-rv/rd*qlh(k))
     presf(k) = presf(k-1)**rdocp - &
@@ -438,12 +438,12 @@ contains
 !           assuming hydrostatic equilibrium      *
 !**************************************************
 
-  !$acc serial default(present) async(1)
+  !$acc serial default(present) async(3) wait(1)
   presh(1) = ps
   thvf(1) = th0av(1)*(1+(rv/rd-1)*qt0av(1)-rv/rd*ql0av(1))
   !$acc end serial
 
-  !$acc serial loop default(present) async(1)
+  !$acc serial loop default(present) async(3) wait(1)
   do k=2,k1
     thvf(k)  = th0av(k)*(1+(rv/rd-1)*qt0av(k)-rv/rd*ql0av(k))
     presh(k) = presh(k-1)**rdocp - &

--- a/src/modtimestat.f90
+++ b/src/modtimestat.f90
@@ -33,7 +33,6 @@
 
 module modtimestat
 
-
   use modprecision, only : longint, field_r
 
 implicit none
@@ -350,6 +349,9 @@ contains
     use modsurface, only : patchxnr,patchynr
     use modmpi,     only : mpi_sum,mpi_max,mpi_min,comm3d,mpierr,myid, D_MPI_ALLREDUCE
     use modstat_nc,  only : lnetcdf, writestat_nc,nc_fillvalue
+#if defined(_OPENACC)
+    use modgpu, only: update_host
+#endif
     implicit none
 
     real   :: zbaseavl, ztopavl, ztopmaxl, ztop,zbaseminl
@@ -378,6 +380,10 @@ contains
     end if
     tnext = tnext+idtav
     dt_lim = minval((/dt_lim,tnext-timee/))
+
+#if defined(_OPENACC)
+    call update_host
+#endif
 
     if (lhetero) then
       zbase_field    = 0

--- a/src/modvarbudget.f90
+++ b/src/modvarbudget.f90
@@ -157,8 +157,10 @@ contains
   end subroutine initvarbudget
 
   subroutine varbudget
-
     use modglobal, only : rk3step,timee,dt_lim
+#if defined(_OPENACC)
+    use modgpu, only: update_host
+#endif
     implicit none
     if (.not. lvarbudget) return
     if (rk3step/=3) return
@@ -169,6 +171,9 @@ contains
     end if
     if (timee>=tnext) then
       tnext = tnext+idtav
+#if defined(_OPENACC)
+      call update_host
+#endif
       call do_varbudget
     end if
     if (timee>=tnextwrite) then

--- a/src/program.f90
+++ b/src/program.f90
@@ -165,7 +165,7 @@ program DALES
 !----------------------------------------------------------------
 
 #if defined(_OPENACC)
-  use modgpu, only: update_gpu
+  use modgpu, only: update_gpu, host_is_updated
 #endif
 
   implicit none
@@ -368,6 +368,9 @@ program DALES
     call timer_toc('Restartfiles')
     call timer_toc('Time step') 
     istep = istep + 1
+#if defined(_OPENACC)
+    host_is_updated = .false.
+#endif
   end do
 
 !-------------------------------------------------------

--- a/src/tstep.f90
+++ b/src/tstep.f90
@@ -284,11 +284,4 @@ subroutine tstep_integrate
   end if
 end subroutine tstep_integrate
 
-!> Calculate the maximum per vertical level for serveral fields
-!subroutine calc_max
-!  use modfields, only : um,vm,wm,up,vp,wp,thlp,svp,qtp,e12p
-!  implicit none
-!
-!end subroutine calc_max
-
 end module tstep

--- a/src/tstep.f90
+++ b/src/tstep.f90
@@ -65,6 +65,7 @@ end subroutine inittstep
 !> Deallocate arrays
 subroutine exittstep
   implicit none
+  !$acc exit data delete(courtotl, courtot)
   deallocate(courtotl)
   deallocate(courtot)
 end subroutine exittstep  


### PR DESCRIPTION
**Offloading**
- [x] Surface module
- [ ] ~Radiation module, only parameterized radiation (for atex case)~
- [ ] ~(optional?) Samptend~
- [ ] ~(optional?) Leibniztend~

**Optimizations**
- [x] `async` where possible
    - [ ] Why does thermo crash when `slabsum` is asynchronous? Scoping?
- [x] Memory usage Poisson solver
    - [x] Use single workspace for FFT's and local transposes
    - [ ] (optional?) Use the halos of the pressure array as a buffer for the FFT's (this will save one 3D array)

**IO**
- [x] Fix restart files
    - [x] Init GPU arrays from restart files
    - [x] Update host, then write restart files
- [x] Statistics
    - [ ] Update only the needed host arrays
    - [x] Update host arrays in every statistics module
    - [x] Make microhh-type switch [`cpu_up_to_date`](https://github.com/microhh/microhh/blob/600faa218383709d2dea26d40b755766a38a8e50/src/model.cxx#L402C29-L402C29)
    - [ ] (optional?) Add OpenMP to statistics routines

**Warnings/errors**
- [ ] Stop if non-accelerated routine is called during a GPU run
- [ ] Stats: give warning if `dtav`/`timeav` is not the same for every file (more data copies!)

**Cleaning up**
- [ ] (optional) Clean up `CMakeLists`
- [x] Free all device memory

**Statistics multithreading**
Idea: use OpenMP tasks to parallelize the statistics routines. Master thread does time stepping, but delegates stats to another thread. First test with only 1 additional thread (this may be enough already). NetCDF is **_not_** thread safe (yet?), so make sure only 1 thread at a time is accessing the NetCDF libraries!